### PR TITLE
gradle-home-cache-cleanupオプションを無効化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Setup Gradle
               uses: gradle/actions/setup-gradle@v3
               with:
-                  gradle-home-cache-cleanup: true  # キャッシュクリーンアップの有効化
+                  gradle-home-cache-cleanup: false
 
             # ktlintによるスタイルチェックを実行
             - name: Run ktlint check
@@ -73,7 +73,7 @@ jobs:
             - name: Setup Gradle
               uses: gradle/actions/setup-gradle@v3
               with:
-                  gradle-home-cache-cleanup: true  # キャッシュクリーンアップの有効化
+                  gradle-home-cache-cleanup: false
 
             # Androidアプリのビルド
             - name: Build Android App
@@ -125,7 +125,7 @@ jobs:
             - name: Setup Gradle
               uses: gradle/actions/setup-gradle@v3
               with:
-                  gradle-home-cache-cleanup: true  # キャッシュクリーンアップの有効化
+                  gradle-home-cache-cleanup: false
 
             # Kotlin Nativeのキャッシュ設定
             - name: Cache Kotlin Native


### PR DESCRIPTION
## 概要
<!-- このPRが解決する問題や追加する機能について簡潔に説明してください -->
masterのCI失敗を解消するために、gradle-home-cache-cleanupオプションを無効化

## 関連Issue
<!-- このPRに関連するIssue番号 (例: #123) -->
なし

## 変更内容
<!-- 実装した内容を簡潔に箇条書きで説明してください -->
- gradle-home-cache-cleanupオプションを無効化

## スクリーンショット（必要な場合）
<!-- UI変更がある場合は、変更前と変更後のスクリーンショットを添付してください -->

## 動作確認項目
<!-- 動作確認した項目をチェックリスト形式で記載してください -->
- [x] Androidの動作確認
- [x] iOSの動作確認

## 懸念事項・注意点
<!-- 実装で迷った点や、後で対応が必要な点などがあれば記載してください -->

## 次のステップ
<!-- このPR後に対応予定の関連タスクがあれば記載してください -->

## セルフレビュー
<!-- 自分自身でのレビュー結果を記載します -->
- [x] コードの整理（不要なコメントの削除、ログの確認など）
- [x] テストが適切に追加されているか
- [x] ドキュメントが更新されているか（必要な場合）
