### PR TITLE
リマインダー登録機能に必要なドメインレイヤーのクラスを実装

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/entity/Reminder.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/entity/Reminder.kt
@@ -8,5 +8,5 @@ package com.maropiyo.reminderparrot.domain.entity
  */
 data class Reminder(
     val id: String? = null,
-    val text: String,
+    val text: String
 )

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/entity/Reminder.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/entity/Reminder.kt
@@ -1,0 +1,12 @@
+package com.maropiyo.reminderparrot.domain.entity
+
+/**
+ * リマインダー
+ *
+ * @param id リマインダーID
+ * @param text リマインダーテキスト
+ */
+data class Reminder(
+    val id: String? = null,
+    val text: String,
+)

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/repository/ReminderRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/repository/ReminderRepository.kt
@@ -1,0 +1,23 @@
+package com.maropiyo.reminderparrot.domain.repository
+
+import com.maropiyo.reminderparrot.domain.entity.Reminder
+
+/**
+ * リマインダーリポジトリ
+ */
+interface ReminderRepository {
+    /**
+     * リマインダーを作成する
+     *
+     * @param reminder リマインダー
+     * @return 作成したリマインダー
+     */
+    suspend fun createReminder(reminder: Reminder): Result<Reminder>
+
+    /**
+     * リマインダーを取得する
+     *
+     * @return リマインダーのリスト
+     */
+    suspend fun getReminders(): Result<List<Reminder>>
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCase.kt
@@ -18,14 +18,11 @@ class CreateReminderUseCase(
      * @param text リマインダーテキスト
      * @return 作成したリマインダー
      */
-    suspend operator fun invoke(
-        id: String,
-        text: String
-    ): Result<Reminder> {
+    suspend operator fun invoke(id: String, text: String): Result<Reminder> {
         val reminder =
             Reminder(
                 id = id,
-                text = text,
+                text = text
             )
 
         return reminderRepository.createReminder(reminder)

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCase.kt
@@ -1,0 +1,33 @@
+package com.maropiyo.reminderparrot.domain.usecase
+
+import com.maropiyo.reminderparrot.domain.entity.Reminder
+import com.maropiyo.reminderparrot.domain.repository.ReminderRepository
+
+/**
+ * リマインダー作成ユースケース
+ *
+ * @property reminderRepository リマインダーリポジトリ
+ */
+class CreateReminderUseCase(
+    private val reminderRepository: ReminderRepository
+) {
+    /**
+     * リマインダーを作成する
+     *
+     * @param id リマインダーID
+     * @param text リマインダーテキスト
+     * @return 作成したリマインダー
+     */
+    suspend operator fun invoke(
+        id: String,
+        text: String
+    ): Result<Reminder> {
+        val reminder =
+            Reminder(
+                id = id,
+                text = text,
+            )
+
+        return reminderRepository.createReminder(reminder)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/GetRemindersUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/GetRemindersUseCase.kt
@@ -1,0 +1,20 @@
+package com.maropiyo.reminderparrot.domain.usecase
+
+import com.maropiyo.reminderparrot.domain.entity.Reminder
+import com.maropiyo.reminderparrot.domain.repository.ReminderRepository
+
+/**
+ * リマインダー取得ユースケース
+ *
+ * @property reminderRepository リマインダーリポジトリ
+ */
+class GetRemindersUseCase(
+    private val reminderRepository: ReminderRepository
+) {
+    /**
+     * リマインダーを取得する
+     *
+     * @return リマインダーのリスト
+     */
+    suspend operator fun invoke(): Result<List<Reminder>> = reminderRepository.getReminders()
+}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要

このプルリクエストでは、アプリケーションでリマインダーを処理するための基本構造が導入されています。`Reminder`エンティティの作成、リマインダーを管理するためのリポジトリインターフェース、そしてリマインダーの作成と取得のための2つのユースケースが含まれています。

### ドメイン層の拡張：
* **リマインダーエンティティ**：オプションの`id`と必須の`text`フィールドを持つリマインダーを表現するための`Reminder`データクラスを追加しました。（`Reminder.kt`）
* **リマインダーリポジトリ**：リマインダーの作成と取得のためのメソッドを持つ`ReminderRepository`インターフェースを導入し、非同期操作をサポートします。（`ReminderRepository.kt`）

### ユースケースの実装：
* **リマインダー作成ユースケース**：`Reminder`を構築し、その作成を`ReminderRepository`に委任する`CreateReminderUseCase`クラスを追加しました。（`CreateReminderUseCase.kt`）
* **リマインダー取得ユースケース**：`ReminderRepository`を通じてリマインダーのリストを取得するための`GetRemindersUseCase`クラスを追加しました。（`GetRemindersUseCase.kt`）

*この文章はGitHubCopilotによって生成されました。*

## 関連Issue
<!-- このPRに関連するIssue番号 (例: #123) -->
Closes #5 
Closes #6 
Closes #7 
Closes #8 

<!-- I want to review in Japanese. -->
