### PR TITLE
feat(ui): ホーム画面にreminko.png表示とUIコンポーネント再構成

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/common/EmptyState.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/common/EmptyState.kt
@@ -1,0 +1,27 @@
+package com.maropiyo.reminderparrot.ui.components.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+/**
+ * 空の状態を表示するコンポーネント
+ * @param emptyMessage 空の状態のメッセージ
+ * @param modifier 修飾子
+ */
+@Composable
+fun EmptyState(emptyMessage: String, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = emptyMessage,
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/common/ErrorState.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/common/ErrorState.kt
@@ -1,0 +1,21 @@
+package com.maropiyo.reminderparrot.ui.components.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+/**
+ * エラーメッセージを表示するコンポーネント
+ */
+@Composable
+fun ErrorState(errorMessage: String, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = errorMessage)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/common/LoadingState.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/common/LoadingState.kt
@@ -1,0 +1,27 @@
+package com.maropiyo.reminderparrot.ui.components.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * 読み込み中の状態を表示するコンポーネント
+ */
+@Composable
+fun LoadingState(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator(
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(48.dp)
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/AddReminderBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/AddReminderBottomSheet.kt
@@ -1,0 +1,240 @@
+package com.maropiyo.reminderparrot.ui.components.home
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.maropiyo.reminderparrot.ui.theme.Background
+import com.maropiyo.reminderparrot.ui.theme.DisableSecondary
+import com.maropiyo.reminderparrot.ui.theme.Secondary
+import com.maropiyo.reminderparrot.ui.theme.Shapes
+import com.maropiyo.reminderparrot.ui.theme.White
+import org.jetbrains.compose.resources.painterResource
+import reminderparrot.composeapp.generated.resources.Res
+import reminderparrot.composeapp.generated.resources.reminko_raising_hand
+
+/**
+ * リマインダー追加ボトムシート
+ *
+ * @param reminderText リマインダーのテキスト
+ * @param onReminderTextChange リマインダーテキストが変更されたときのコールバック
+ * @param onDismiss ボトムシートが閉じられたときのコールバック
+ * @param onSaveReminder リマインダーが保存されたときのコールバック
+ * @param sheetState ボトムシートの状態
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddReminderBottomSheet(
+    reminderText: String,
+    onReminderTextChange: (String) -> Unit,
+    onDismiss: () -> Unit,
+    onSaveReminder: () -> Unit,
+    sheetState: androidx.compose.material3.SheetState
+) {
+    ModalBottomSheet(
+        dragHandle = null,
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = Color.Transparent
+    ) {
+        Box(
+            modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp)
+                .imePadding()
+        ) {
+            ReminderInputCard(
+                reminderText = reminderText,
+                onReminderTextChange = onReminderTextChange,
+                onSaveReminder = onSaveReminder,
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 104.dp)
+            )
+
+            // リマインコの画像
+            Image(
+                painter = painterResource(Res.drawable.reminko_raising_hand),
+                contentDescription = "Parrot",
+                modifier =
+                Modifier
+                    .size(128.dp)
+                    .align(Alignment.TopCenter),
+                contentScale = ContentScale.Crop
+            )
+        }
+    }
+}
+
+/**
+ * リマインダー入力カード
+ */
+@Composable
+private fun ReminderInputCard(
+    reminderText: String,
+    onReminderTextChange: (String) -> Unit,
+    onSaveReminder: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        colors =
+        CardDefaults.cardColors(
+            containerColor = Background
+        ),
+        shape = Shapes.extraLarge
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 24.dp)
+        ) {
+            // タイトルテキスト
+            Text(
+                text = "よんだ？",
+                color = Secondary,
+                style = MaterialTheme.typography.titleLarge
+            )
+
+            Spacer(Modifier.size(16.dp))
+
+            // テキスト入力フィールド
+            ReminderTextField(
+                reminderText = reminderText,
+                onValueChange = onReminderTextChange,
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            )
+
+            Spacer(Modifier.size(16.dp))
+
+            // 送信ボタン
+            SaveReminderButton(
+                onClick = onSaveReminder,
+                enabled = reminderText.isNotBlank(),
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .height(50.dp)
+            )
+        }
+    }
+}
+
+/**
+ * リマインダーテキスト入力フィールド
+ *
+ * @param reminderText リマインダーテキスト
+ * @param onValueChange テキストが変更されたときのコールバック
+ * @param modifier 修飾子
+ */
+@Composable
+private fun ReminderTextField(reminderText: String, onValueChange: (String) -> Unit, modifier: Modifier = Modifier) {
+    // 初期テキストとカーソル位置を保持するための状態
+    var textFieldValue by remember {
+        mutableStateOf(
+            TextFieldValue(
+                text = reminderText,
+                selection = TextRange(reminderText.length)
+            )
+        )
+    }
+
+    TextField(
+        value = textFieldValue,
+        onValueChange = { changedValue ->
+            textFieldValue = changedValue
+            onValueChange(changedValue.text)
+        },
+        modifier = modifier,
+        colors =
+        TextFieldDefaults.colors(
+            focusedTextColor = Secondary,
+            focusedContainerColor = White,
+            unfocusedContainerColor = White,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent
+        ),
+        textStyle =
+        MaterialTheme.typography.bodyLarge.copy(
+            color = Secondary,
+            fontWeight = FontWeight.Bold
+        ),
+        placeholder =
+        {
+            Text(
+                text = "おしえることばをかいてね",
+                style = MaterialTheme.typography.bodyLarge,
+                color = Secondary.copy(alpha = 0.5f)
+            )
+        },
+        singleLine = true,
+        shape = Shapes.large
+    )
+}
+
+/**
+ * リマインダー保存ボタン
+ *
+ * @param onClick ボタンがクリックされたときの処理
+ * @param enabled ボタンが有効かどうか
+ * @param modifier ボタンの修飾子
+ */
+@Composable
+private fun SaveReminderButton(onClick: () -> Unit, enabled: Boolean, modifier: Modifier = Modifier) {
+    ElevatedButton(
+        onClick = onClick,
+        modifier = modifier,
+        shape = Shapes.large,
+        colors =
+        ButtonDefaults.elevatedButtonColors(
+            containerColor = Secondary,
+            contentColor = White,
+            disabledContainerColor = DisableSecondary,
+            disabledContentColor = White
+        ),
+        enabled = enabled
+    ) {
+        Text(
+            text = "おしえる",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ParrotSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ParrotSection.kt
@@ -1,0 +1,39 @@
+package com.maropiyo.reminderparrot.ui.components.home
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.painterResource
+import reminderparrot.composeapp.generated.resources.Res
+import reminderparrot.composeapp.generated.resources.reminko
+
+/**
+ * Parrotセクション
+ * ホーム画面上部にReminkoのキャラクターを表示
+ *
+ * @param modifier 修飾子
+ */
+@Composable
+fun ParrotSection(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Reminkoの画像
+        Image(
+            painter = painterResource(Res.drawable.reminko),
+            contentDescription = "Reminko Parrot",
+            modifier = Modifier.size(120.dp),
+            contentScale = ContentScale.Fit
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderList.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderList.kt
@@ -1,0 +1,129 @@
+package com.maropiyo.reminderparrot.ui.components.home
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import com.maropiyo.reminderparrot.domain.entity.Reminder
+import com.maropiyo.reminderparrot.ui.theme.Secondary
+import com.maropiyo.reminderparrot.ui.theme.White
+
+@Composable
+fun ReminderList(reminders: List<Reminder>, onToggleCompletion: (String) -> Unit, modifier: Modifier = Modifier) {
+    LazyColumn(
+        modifier =
+        modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        items(reminders) { reminder ->
+            ReminderCard(
+                reminder = reminder,
+                onToggleCompletion = { onToggleCompletion(reminder.id) },
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+        }
+    }
+}
+
+@Composable
+fun ReminderCard(reminder: Reminder, onToggleCompletion: () -> Unit, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors =
+        CardDefaults.cardColors(
+            containerColor = White
+        ),
+        shape = MaterialTheme.shapes.medium
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // テキスト
+            Text(
+                text = reminder.text,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = Secondary,
+                textDecoration = if (reminder.isCompleted) TextDecoration.LineThrough else TextDecoration.None,
+                modifier = Modifier.weight(1f)
+            )
+
+            // 丸いチェックボックス
+            CircularCheckbox(
+                checked = reminder.isCompleted,
+                onCheckedChange = { onToggleCompletion() },
+                modifier = Modifier.size(32.dp)
+            )
+        }
+    }
+}
+
+/**
+ * 円形のチェックボックス
+ */
+@Composable
+private fun CircularCheckbox(checked: Boolean, onCheckedChange: (Boolean) -> Unit, modifier: Modifier = Modifier) {
+    val scale by animateFloatAsState(
+        targetValue = if (checked) 0.9f else 0f,
+        label = "checkmark_scale"
+    )
+
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .border(
+                width = 2.dp,
+                color = Secondary,
+                shape = CircleShape
+            )
+            .background(
+                color = if (checked) Secondary else White,
+                shape = CircleShape
+            )
+            .clickable { onCheckedChange(!checked) },
+        contentAlignment = Alignment.Center
+    ) {
+        if (checked) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = "Checked",
+                tint = White,
+                modifier = Modifier
+                    .size(20.dp)
+                    .scale(scale)
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderSection.kt
@@ -1,0 +1,148 @@
+package com.maropiyo.reminderparrot.ui.components.home
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.unit.dp
+import com.maropiyo.reminderparrot.presentation.state.ReminderListState
+import com.maropiyo.reminderparrot.ui.components.common.EmptyState
+import com.maropiyo.reminderparrot.ui.components.common.ErrorState
+import com.maropiyo.reminderparrot.ui.components.common.LoadingState
+import com.maropiyo.reminderparrot.ui.theme.ParrotYellow
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.painterResource
+import reminderparrot.composeapp.generated.resources.Res
+import reminderparrot.composeapp.generated.resources.reminko_face
+
+/**
+ * リマインダーセクション
+ * リマインダー一覧の表示と操作を担当するコンポーネント
+ *
+ * @param state リマインダーリストの状態
+ * @param onToggleCompletion リマインダー完了切り替えコールバック
+ * @param onCreateReminder 新しいリマインダー作成コールバック
+ * @param modifier 修飾子
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReminderSection(
+    state: ReminderListState,
+    onToggleCompletion: (String) -> Unit,
+    onCreateReminder: suspend (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // ボトムシートの表示状態
+    var isShowBottomSheet by remember { mutableStateOf(false) }
+    // リマインダーテキスト
+    var reminderText by remember { mutableStateOf("") }
+    // ボトムシートの状態
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    // コルーチンスコープとキーボードコントローラーの取得
+    val scope = rememberCoroutineScope()
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    Box(modifier = modifier) {
+        // メインコンテンツの表示
+        ReminderContent(
+            state = state,
+            onToggleCompletion = onToggleCompletion,
+            modifier = Modifier.fillMaxSize()
+        )
+
+        // フローティングアクションボタン
+        ReminderFloatingActionButton(
+            onClick = {
+                reminderText = ""
+                isShowBottomSheet = true
+            },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp)
+        )
+
+        // リマインダー追加用ボトムシート
+        if (isShowBottomSheet) {
+            AddReminderBottomSheet(
+                reminderText = reminderText,
+                onReminderTextChange = { reminderText = it },
+                onDismiss = {
+                    keyboardController?.hide()
+                    isShowBottomSheet = false
+                    reminderText = ""
+                },
+                onSaveReminder = {
+                    scope.launch {
+                        onCreateReminder(reminderText)
+                        isShowBottomSheet = false
+                        reminderText = ""
+                        sheetState.hide()
+                    }
+                },
+                sheetState = sheetState
+            )
+        }
+    }
+}
+
+/**
+ * リマインダー用フローティングアクションボタン
+ */
+@Composable
+private fun ReminderFloatingActionButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    FloatingActionButton(
+        onClick = onClick,
+        containerColor = ParrotYellow,
+        modifier = modifier
+    ) {
+        Image(
+            painter = painterResource(Res.drawable.reminko_face),
+            contentDescription = "Parrot",
+            modifier = Modifier.size(48.dp),
+            contentScale = ContentScale.Crop
+        )
+    }
+}
+
+/**
+ * リマインダーコンテンツ
+ */
+@Composable
+private fun ReminderContent(
+    state: ReminderListState,
+    onToggleCompletion: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    when {
+        state.isLoading -> {
+            LoadingState(modifier = modifier)
+        }
+        state.error != null -> {
+            ErrorState(state.error, modifier = modifier)
+        }
+        state.reminders.isEmpty() -> {
+            EmptyState("リマインダーがありません", modifier = modifier)
+        }
+        else -> {
+            ReminderList(
+                reminders = state.reminders,
+                onToggleCompletion = onToggleCompletion,
+                modifier = modifier
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
@@ -1,143 +1,59 @@
 package com.maropiyo.reminderparrot.ui.screens
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
-import com.maropiyo.reminderparrot.presentation.state.ReminderListState
 import com.maropiyo.reminderparrot.presentation.viewmodel.ReminderListViewModel
-import com.maropiyo.reminderparrot.ui.components.reminder.AddReminderBottomSheet
-import com.maropiyo.reminderparrot.ui.components.reminder.ReminderList
-import com.maropiyo.reminderparrot.ui.components.state.EmptyState
-import com.maropiyo.reminderparrot.ui.components.state.ErrorState
-import com.maropiyo.reminderparrot.ui.components.state.LoadingState
-import com.maropiyo.reminderparrot.ui.theme.ParrotYellow
-import kotlinx.coroutines.launch
-import org.jetbrains.compose.resources.painterResource
+import com.maropiyo.reminderparrot.ui.components.home.ParrotSection
+import com.maropiyo.reminderparrot.ui.components.home.ReminderSection
 import org.koin.compose.viewmodel.koinViewModel
-import reminderparrot.composeapp.generated.resources.Res
-import reminderparrot.composeapp.generated.resources.reminko_face
 
 /**
  * ホーム画面
- * @param viewModel ViewModel
+ * Parrotセクションとリマインダーセクションを含む統合画面
+ *
+ * @param reminderListViewModel リマインダーリストのViewModel
  * @param modifier 修飾子
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeScreen(viewModel: ReminderListViewModel = koinViewModel(), modifier: Modifier = Modifier) {
+fun HomeScreen(
+    reminderListViewModel: ReminderListViewModel = koinViewModel(),
+    modifier: Modifier = Modifier
+) {
     // ViewModelの状態を取得
-    val state by viewModel.state.collectAsState()
+    val state by reminderListViewModel.state.collectAsState()
 
-    // ボトムシートの表示状態
-    var isShowBottomSheet by remember { mutableStateOf(false) }
-    // リマインダーテキスト
-    var reminderText by remember { mutableStateOf("") }
-    // ボトムシートの状態
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    // コルーチンスコープとキーボードコントローラーの取得
-    val scope = rememberCoroutineScope()
-    val keyboardController = LocalSoftwareKeyboardController.current
-
-    Box(modifier = modifier) {
-        // メインコンテンツの表示
-        HomeContent(
-            state = state,
-            onToggleCompletion = viewModel::toggleReminderCompletion,
-            modifier = Modifier.fillMaxSize()
-        )
-
-        // フローティングアクションボタン
-        HomeFloatingActionButton(
-            onClick = {
-                reminderText = ""
-                isShowBottomSheet = true
-            },
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(16.dp)
-        )
-
-        // リマインダー追加用ボトムシート
-        if (isShowBottomSheet) {
-            AddReminderBottomSheet(
-                reminderText = reminderText,
-                onReminderTextChange = { reminderText = it },
-                onDismiss = {
-                    keyboardController?.hide()
-                    isShowBottomSheet = false
-                    reminderText = ""
-                },
-                onSaveReminder = {
-                    scope.launch {
-                        viewModel.createReminder(reminderText)
-                        isShowBottomSheet = false
-                        reminderText = ""
-                        sheetState.hide()
-                    }
-                },
-                sheetState = sheetState
-            )
-        }
-    }
-}
-
-/**
- * フローティングアクションボタン
- */
-@Composable
-private fun HomeFloatingActionButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
-    FloatingActionButton(
-        onClick = onClick,
-        containerColor = ParrotYellow,
-        modifier = modifier
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Image(
-            painter = painterResource(Res.drawable.reminko_face),
-            contentDescription = "Parrot",
-            modifier = Modifier.size(48.dp),
-            contentScale = ContentScale.Crop
+        // Parrotセクション（reminko.pngを表示）
+        ParrotSection(
+            modifier = Modifier.fillMaxWidth()
         )
-    }
-}
 
-/**
- * コンテンツ
- */
-@Composable
-private fun HomeContent(state: ReminderListState, onToggleCompletion: (String) -> Unit, modifier: Modifier = Modifier) {
-    when {
-        state.isLoading -> {
-            LoadingState(modifier = modifier)
-        }
-        state.error != null -> {
-            ErrorState(state.error, modifier = modifier)
-        }
-        state.reminders.isEmpty() -> {
-            EmptyState("リマインダーがありません", modifier = modifier)
-        }
-        else -> {
-            ReminderList(
-                reminders = state.reminders,
-                onToggleCompletion = onToggleCompletion,
-                modifier = modifier
-            )
-        }
+        // リマインダーセクション
+        ReminderSection(
+            state = state,
+            onToggleCompletion = reminderListViewModel::toggleReminderCompletion,
+            onCreateReminder = { text ->
+                reminderListViewModel.createReminder(text)
+            },
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+        )
     }
 }


### PR DESCRIPTION
## Summary
- ホーム画面にreminko.pngを表示するParrotSectionコンポーネントを追加
- UIコンポーネントを論理的なディレクトリ構造に再組織化
- HomeScreenを新しいコンポーネント構造に対応させてリファクタリング

## Changes
### 新規追加
- `ParrotSection`: reminko.png画像を表示するシンプルなコンポーネント
- `ui/components/common/`: 汎用コンポーネント（EmptyState, ErrorState, LoadingState）
- `ui/components/home/`: ホーム画面専用コンポーネント

### 構造改善
- コンポーネントを画面別・用途別に論理的に分離
- HomeScreenを簡潔なColumn構造に変更
- パッケージ宣言とインポート文を新構造に合わせて更新

## Test plan
- [ ] Android実機でホーム画面にreminko.pngが正しく表示される
- [ ] iOS実機でホーム画面にreminko.pngが正しく表示される
- [ ] リマインダー機能が引き続き正常に動作する
- [ ] フローティングアクションボタンからリマインダー追加が可能
- [ ] スクロール動作が正常に機能する

🤖 Generated with [Claude Code](https://claude.ai/code)