### PR TITLE
feat(parrot): 経験値システムとレベルアップダイアログ機能の完全実装

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/local/ParrotLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/local/ParrotLocalDataSource.kt
@@ -1,0 +1,54 @@
+package com.maropiyo.reminderparrot.data.local
+
+import com.maropiyo.reminderparrot.data.mapper.ParrotMapper
+import com.maropiyo.reminderparrot.db.ReminderParrotDatabase
+import com.maropiyo.reminderparrot.domain.entity.Parrot
+
+/**
+ * インコのローカルデータソース
+ *
+ * @property database データベース
+ * @property parrotMapper インコマッパー
+ */
+class ParrotLocalDataSource(
+    private val database: ReminderParrotDatabase,
+    private val parrotMapper: ParrotMapper
+) {
+    /**
+     * インコのデータを取得する
+     *
+     * @return インコのデータ（存在しない場合はnull）
+     */
+    fun getParrot(): Parrot? =
+        database.reminderParrotDatabaseQueries.selectParrot(parrotMapper::mapFromDatabase).executeAsOneOrNull()
+
+    /**
+     * インコのデータを保存する
+     *
+     * @param parrot インコのデータ
+     */
+    fun saveParrot(parrot: Parrot) {
+        database.reminderParrotDatabaseQueries.insertParrot(
+            level = parrot.level.toLong(),
+            current_experience = parrot.currentExperience.toLong(),
+            max_experience = parrot.maxExperience.toLong(),
+            memorized_words = parrot.memorizedWords.toLong(),
+            memory_time_hours = parrot.memoryTimeHours.toLong()
+        )
+    }
+
+    /**
+     * インコのデータを更新する
+     *
+     * @param parrot インコのデータ
+     */
+    fun updateParrot(parrot: Parrot) {
+        database.reminderParrotDatabaseQueries.updateParrot(
+            level = parrot.level.toLong(),
+            current_experience = parrot.currentExperience.toLong(),
+            max_experience = parrot.maxExperience.toLong(),
+            memorized_words = parrot.memorizedWords.toLong(),
+            memory_time_hours = parrot.memoryTimeHours.toLong()
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/mapper/ParrotMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/mapper/ParrotMapper.kt
@@ -1,0 +1,34 @@
+package com.maropiyo.reminderparrot.data.mapper
+
+import com.maropiyo.reminderparrot.domain.entity.Parrot
+
+/**
+ * インコのマッパー
+ */
+class ParrotMapper {
+    /**
+     * SQLDelightのクエリ結果をエンティティに変換する
+     *
+     * @param id ID（使用しない）
+     * @param level かしこさレベル
+     * @param current_experience 現在の経験値
+     * @param max_experience レベルアップに必要な経験値
+     * @param memorized_words 覚えられることばの数
+     * @param memory_time_hours 記憶時間(時間)
+     * @return インコ
+     */
+    fun mapFromDatabase(
+        id: Long,
+        level: Long,
+        current_experience: Long,
+        max_experience: Long,
+        memorized_words: Long,
+        memory_time_hours: Long
+    ): Parrot = Parrot(
+        level = level.toInt(),
+        currentExperience = current_experience.toInt(),
+        maxExperience = max_experience.toInt(),
+        memorizedWords = memorized_words.toInt(),
+        memoryTimeHours = memory_time_hours.toInt()
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
@@ -1,6 +1,8 @@
 package com.maropiyo.reminderparrot.di
 
+import com.maropiyo.reminderparrot.data.local.ParrotLocalDataSource
 import com.maropiyo.reminderparrot.data.local.ReminderLocalDataSource
+import com.maropiyo.reminderparrot.data.mapper.ParrotMapper
 import com.maropiyo.reminderparrot.data.mapper.ReminderMapper
 import com.maropiyo.reminderparrot.data.repository.ParrotRepositoryImpl
 import com.maropiyo.reminderparrot.data.repository.ReminderRepositoryImpl
@@ -34,13 +36,15 @@ val appModule =
 
         // Repository
         single<ReminderRepository> { ReminderRepositoryImpl(get(), get()) }
-        single<ParrotRepository> { ParrotRepositoryImpl() }
+        single<ParrotRepository> { ParrotRepositoryImpl(get()) }
 
         // Mapper
         single { ReminderMapper() }
+        single { ParrotMapper() }
 
         // LocalDataSource
         single<ReminderLocalDataSource> { ReminderLocalDataSource(get(), get()) }
+        single<ParrotLocalDataSource> { ParrotLocalDataSource(get(), get()) }
 
         // Common
         single<UuidGenerator> { UuidGenerator() }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
@@ -7,6 +7,7 @@ import com.maropiyo.reminderparrot.data.repository.ReminderRepositoryImpl
 import com.maropiyo.reminderparrot.domain.common.UuidGenerator
 import com.maropiyo.reminderparrot.domain.repository.ParrotRepository
 import com.maropiyo.reminderparrot.domain.repository.ReminderRepository
+import com.maropiyo.reminderparrot.domain.usecase.AddParrotExperienceUseCase
 import com.maropiyo.reminderparrot.domain.usecase.CreateReminderUseCase
 import com.maropiyo.reminderparrot.domain.usecase.GetParrotUseCase
 import com.maropiyo.reminderparrot.domain.usecase.GetRemindersUseCase
@@ -21,7 +22,7 @@ import org.koin.dsl.module
 val appModule =
     module {
         // ViewModel
-        single<ReminderListViewModel> { ReminderListViewModel(get(), get(), get()) }
+        single<ReminderListViewModel> { ReminderListViewModel(get(), get(), get(), get()) }
         single<ParrotViewModel> { ParrotViewModel(get()) }
 
         // UseCase
@@ -29,6 +30,7 @@ val appModule =
         single<GetRemindersUseCase> { GetRemindersUseCase(get()) }
         single<UpdateReminderUseCase> { UpdateReminderUseCase(get()) }
         single<GetParrotUseCase> { GetParrotUseCase(get()) }
+        single<AddParrotExperienceUseCase> { AddParrotExperienceUseCase(get()) }
 
         // Repository
         single<ReminderRepository> { ReminderRepositoryImpl(get(), get()) }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/AddParrotExperienceUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/AddParrotExperienceUseCase.kt
@@ -1,0 +1,27 @@
+package com.maropiyo.reminderparrot.domain.usecase
+
+import com.maropiyo.reminderparrot.domain.entity.Parrot
+import com.maropiyo.reminderparrot.domain.repository.ParrotRepository
+
+/**
+ * インコの経験値を追加するユースケース
+ *
+ * リマインダー追加時などに経験値を加算する
+ *
+ * @property parrotRepository インコリポジトリ
+ */
+class AddParrotExperienceUseCase(
+    private val parrotRepository: ParrotRepository
+) {
+    /**
+     * 経験値を追加する
+     *
+     * デフォルトで1ポイントの経験値を追加
+     *
+     * @param experience 追加する経験値（デフォルト: 1）
+     * @return 更新されたインコの状態
+     */
+    suspend operator fun invoke(experience: Int = 1): Result<Parrot> {
+        return parrotRepository.addExperience(experience)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ParrotViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ParrotViewModel.kt
@@ -28,7 +28,7 @@ class ParrotViewModel(
     /**
      * インコの状態を読み込む
      */
-    private fun loadParrot() {
+    fun loadParrot() {
         viewModelScope.launch {
             _state.update { it.copy(isLoading = true, error = null) }
 

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ReminderListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ReminderListViewModel.kt
@@ -3,6 +3,7 @@ package com.maropiyo.reminderparrot.presentation.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.maropiyo.reminderparrot.domain.entity.Reminder
+import com.maropiyo.reminderparrot.domain.usecase.AddParrotExperienceUseCase
 import com.maropiyo.reminderparrot.domain.usecase.CreateReminderUseCase
 import com.maropiyo.reminderparrot.domain.usecase.GetRemindersUseCase
 import com.maropiyo.reminderparrot.domain.usecase.UpdateReminderUseCase
@@ -19,11 +20,13 @@ import kotlinx.coroutines.launch
  * @property getRemindersUseCase リマインダー取得ユースケース
  * @property createReminderUseCase リマインダー作成ユースケース
  * @property updateReminderUseCase リマインダー更新ユースケース
+ * @property addParrotExperienceUseCase インコの経験値追加ユースケース
  */
 class ReminderListViewModel(
     private val getRemindersUseCase: GetRemindersUseCase,
     private val createReminderUseCase: CreateReminderUseCase,
-    private val updateReminderUseCase: UpdateReminderUseCase
+    private val updateReminderUseCase: UpdateReminderUseCase,
+    private val addParrotExperienceUseCase: AddParrotExperienceUseCase
 ) : ViewModel() {
     private val _state = MutableStateFlow(ReminderListState())
     val state: StateFlow<ReminderListState> = _state.asStateFlow()
@@ -59,6 +62,8 @@ class ReminderListViewModel(
                             error = null
                         )
                     }
+                    // インコの経験値を追加（+1）
+                    addParrotExperienceUseCase()
                 }.onFailure { exception ->
                     // リマインダーの作成に失敗した場合、エラーメッセージを表示する
                     _state.update { it.copy(error = exception.message) }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ReminderListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ReminderListViewModel.kt
@@ -90,6 +90,11 @@ class ReminderListViewModel(
                             }
                         currentState.copy(reminders = sortReminders(updatedReminders))
                     }
+
+                    // リマインダーが完了状態になった場合のみ経験値を追加
+                    if (updatedReminder.isCompleted) {
+                        addParrotExperienceUseCase()
+                    }
                 }.onFailure { exception ->
                     _state.update { it.copy(error = exception.message) }
                 }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/LevelUpPopup.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/LevelUpPopup.kt
@@ -1,0 +1,166 @@
+package com.maropiyo.reminderparrot.ui.components.home
+
+import androidx.compose.animation.core.EaseOutBounce
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogProperties
+import com.maropiyo.reminderparrot.domain.entity.Parrot
+import org.jetbrains.compose.resources.painterResource
+import reminderparrot.composeapp.generated.resources.Res
+import reminderparrot.composeapp.generated.resources.reminko_jump
+
+/**
+ * レベルアップ時に表示するお祝いダイアログ
+ *
+ * @param isVisible ダイアログの表示状態
+ * @param parrot パロットの状態情報
+ * @param onDismiss ダイアログを閉じる時のコールバック
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LevelUpDialog(isVisible: Boolean, parrot: Parrot, onDismiss: () -> Unit) {
+    if (isVisible) {
+        BasicAlertDialog(
+            onDismissRequest = onDismiss,
+            properties = DialogProperties(
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true
+            )
+        ) {
+            Card(
+                modifier = Modifier
+                    .padding(24.dp)
+                    .widthIn(min = 300.dp, max = 400.dp)
+                    .fillMaxWidth(),
+                shape = RoundedCornerShape(24.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = Color(0xFFFFF8E1)
+                ),
+                elevation = CardDefaults.cardElevation(
+                    defaultElevation = 8.dp
+                )
+            ) {
+                Column(
+                    modifier = Modifier
+                        .padding(32.dp)
+                        .fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(20.dp)
+                ) {
+                    // お祝いメッセージ
+                    Text(
+                        text = "レベルアップ！",
+                        fontSize = 28.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFFFF6B35),
+                        textAlign = TextAlign.Center,
+                        maxLines = 1
+                    )
+
+                    // ジャンプしているレミンコ
+                    val transition = updateTransition(
+                        targetState = isVisible,
+                        label = "parrot_animation"
+                    )
+
+                    val rotation by transition.animateFloat(
+                        label = "rotation",
+                        transitionSpec = {
+                            if (targetState) {
+                                tween(
+                                    durationMillis = 1000,
+                                    easing = EaseOutBounce
+                                )
+                            } else {
+                                tween(300)
+                            }
+                        }
+                    ) { visible ->
+                        if (visible) 360f else 0f
+                    }
+
+                    Image(
+                        painter = painterResource(Res.drawable.reminko_jump),
+                        contentDescription = "喜ぶレミンコ",
+                        modifier = Modifier
+                            .size(120.dp)
+                            .rotate(rotation)
+                    )
+
+                    // レベル表示
+                    Text(
+                        text = "レベル ${parrot.level}",
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+
+                    // 能力向上表示
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            text = "能力がアップしたよ！",
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Medium,
+                            color = Color(0xFF795548)
+                        )
+
+                        Text(
+                            text = "おぼえられることば: ${parrot.memorizedWords}こ",
+                            fontSize = 14.sp,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+
+                        Text(
+                            text = "きおくじかん: ${parrot.memoryTimeHours}じかん",
+                            fontSize = 14.sp,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+
+                    // やったー！ボタン
+                    Button(
+                        onClick = onDismiss,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp)
+                    ) {
+                        Text(
+                            text = "やったー！",
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/LevelUpPopup.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/LevelUpPopup.kt
@@ -13,9 +13,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.BasicAlertDialog
-import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -31,6 +32,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.DialogProperties
 import com.maropiyo.reminderparrot.domain.entity.Parrot
+import com.maropiyo.reminderparrot.ui.theme.Secondary
+import com.maropiyo.reminderparrot.ui.theme.Shapes
+import com.maropiyo.reminderparrot.ui.theme.White
 import org.jetbrains.compose.resources.painterResource
 import reminderparrot.composeapp.generated.resources.Res
 import reminderparrot.composeapp.generated.resources.reminko_jump
@@ -127,7 +131,7 @@ fun LevelUpDialog(isVisible: Boolean, parrot: Parrot, onDismiss: () -> Unit) {
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Text(
-                            text = "能力がアップしたよ！",
+                            text = "かしこくなったよ！",
                             fontSize = 16.sp,
                             fontWeight = FontWeight.Medium,
                             color = Color(0xFF795548)
@@ -147,15 +151,20 @@ fun LevelUpDialog(isVisible: Boolean, parrot: Parrot, onDismiss: () -> Unit) {
                     }
 
                     // やったー！ボタン
-                    Button(
+                    ElevatedButton(
                         onClick = onDismiss,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(top = 8.dp)
+                            .padding(top = 8.dp),
+                        shape = Shapes.large,
+                        colors = ButtonDefaults.elevatedButtonColors(
+                            containerColor = Secondary,
+                            contentColor = White
+                        )
                     ) {
                         Text(
                             text = "やったー！",
-                            fontSize = 18.sp,
+                            style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ParrotContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ParrotContent.kt
@@ -122,6 +122,7 @@ fun ParrotContent(state: ParrotState, modifier: Modifier = Modifier) {
                             skipAnimation = false
                             displayProgress = 1f
                             delay(1000) // アニメーション完了まで待機
+
                             previousLevel = state.parrot.level
                             // 新レベルの初期値に即座にリセット（アニメーションなし）
                             skipAnimation = true

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ParrotContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ParrotContent.kt
@@ -1,5 +1,7 @@
 package com.maropiyo.reminderparrot.ui.components.home
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -15,6 +17,11 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,6 +39,7 @@ import com.maropiyo.reminderparrot.ui.theme.Gray
 import com.maropiyo.reminderparrot.ui.theme.Secondary
 import com.maropiyo.reminderparrot.ui.theme.Shapes
 import com.maropiyo.reminderparrot.ui.theme.White
+import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.painterResource
 import reminderparrot.composeapp.generated.resources.Res
 import reminderparrot.composeapp.generated.resources.reminko
@@ -43,26 +51,30 @@ import reminderparrot.composeapp.generated.resources.reminko
  * @param modifier 修飾子
  */
 @Composable
-fun ParrotContent(state: ParrotState, modifier: Modifier = Modifier) {
+fun ParrotContent(
+    state: ParrotState,
+    modifier: Modifier = Modifier
+) {
     Card(
         modifier =
-        modifier
-            .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 8.dp),
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 8.dp),
         shape = Shapes.extraLarge,
         colors =
-        CardDefaults.cardColors(
-            containerColor = White
-        ),
-        elevation = CardDefaults.cardElevation(
-            defaultElevation = 4.dp
-        )
+            CardDefaults.cardColors(
+                containerColor = White
+            ),
+        elevation =
+            CardDefaults.cardElevation(
+                defaultElevation = 4.dp
+            )
     ) {
         Row(
             modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
+                Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
             horizontalArrangement = Arrangement.spacedBy(20.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -74,10 +86,10 @@ fun ParrotContent(state: ParrotState, modifier: Modifier = Modifier) {
                 Text(
                     text = "レベル${state.parrot.level}",
                     style =
-                    MaterialTheme.typography.labelMedium.copy(
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 16.sp
-                    ),
+                        MaterialTheme.typography.labelMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 16.sp
+                        ),
                     color = Secondary
                 )
                 // インコと丸型経験値インジケータ
@@ -85,6 +97,59 @@ fun ParrotContent(state: ParrotState, modifier: Modifier = Modifier) {
                     modifier = Modifier.size(100.dp),
                     contentAlignment = Alignment.Center
                 ) {
+                    // 前回のレベルを記憶
+                    var previousLevel by remember { mutableStateOf(state.parrot.level) }
+                    var displayProgress by remember {
+                        mutableStateOf(
+                            if (state.parrot.maxExperience > 0) {
+                                state.parrot.currentExperience.toFloat() / state.parrot.maxExperience.toFloat()
+                            } else {
+                                0f
+                            }
+                        )
+                    }
+                    var skipAnimation by remember { mutableStateOf(false) }
+
+                    // 現在の実際の進捗を計算
+                    val actualProgress =
+                        if (state.parrot.maxExperience > 0) {
+                            state.parrot.currentExperience.toFloat() / state.parrot.maxExperience.toFloat()
+                        } else {
+                            0f
+                        }
+
+                    // レベルアップを検出
+                    LaunchedEffect(state.parrot.level, state.parrot.currentExperience) {
+                        if (state.parrot.level > previousLevel) {
+                            // レベルアップした場合、まず100%まで上昇させる
+                            skipAnimation = false
+                            displayProgress = 1f
+                            delay(1000) // アニメーション完了まで待機
+                            previousLevel = state.parrot.level
+                            // 新レベルの初期値に即座にリセット（アニメーションなし）
+                            skipAnimation = true
+                            displayProgress = actualProgress
+                            // 次回のアニメーションを有効にする
+                            delay(50) // 状態更新を確実にするための短い遅延
+                            skipAnimation = false
+                        } else {
+                            // 通常の経験値増加
+                            displayProgress = actualProgress
+                        }
+                    }
+
+                    // アニメーション付き進捗
+                    val animatedProgress by animateFloatAsState(
+                        targetValue = displayProgress,
+                        animationSpec =
+                            if (skipAnimation) {
+                                tween(durationMillis = 0) // 即座に変更
+                            } else {
+                                tween(durationMillis = 1000) // 通常のアニメーション
+                            },
+                        label = "experience_progress"
+                    )
+
                     // 丸型経験値インジケータ
                     Canvas(
                         modifier = Modifier.size(100.dp)
@@ -102,24 +167,17 @@ fun ParrotContent(state: ParrotState, modifier: Modifier = Modifier) {
                         )
 
                         // 経験値円弧
-                        val progress =
-                            if (state.parrot.maxExperience > 0) {
-                                state.parrot.currentExperience.toFloat() / state.parrot.maxExperience.toFloat()
-                            } else {
-                                0f
-                            }
-
-                        if (progress > 0) {
+                        if (animatedProgress > 0) {
                             drawArc(
                                 color = Secondary,
                                 startAngle = -90f,
-                                sweepAngle = 360f * progress,
+                                sweepAngle = 360f * animatedProgress,
                                 useCenter = false,
                                 topLeft =
-                                Offset(
-                                    center.x - radius,
-                                    center.y - radius
-                                ),
+                                    Offset(
+                                        center.x - radius,
+                                        center.y - radius
+                                    ),
                                 size = Size(radius * 2, radius * 2),
                                 style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
                             )
@@ -145,10 +203,10 @@ fun ParrotContent(state: ParrotState, modifier: Modifier = Modifier) {
                 Text(
                     text = "できること",
                     style =
-                    MaterialTheme.typography.titleMedium.copy(
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 16.sp
-                    ),
+                        MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 16.sp
+                        ),
                     color = Secondary
                 )
 
@@ -159,11 +217,11 @@ fun ParrotContent(state: ParrotState, modifier: Modifier = Modifier) {
                     // おぼえられることば
                     Row(
                         modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .clip(Shapes.large)
-                            .background(MaterialTheme.colorScheme.background)
-                            .padding(horizontal = 12.dp, vertical = 10.dp),
+                            Modifier
+                                .fillMaxWidth()
+                                .clip(Shapes.large)
+                                .background(MaterialTheme.colorScheme.background)
+                                .padding(horizontal = 12.dp, vertical = 10.dp),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -176,9 +234,9 @@ fun ParrotContent(state: ParrotState, modifier: Modifier = Modifier) {
                         Text(
                             text = "${state.parrot.memorizedWords}こ",
                             style =
-                            MaterialTheme.typography.titleMedium.copy(
-                                fontWeight = FontWeight.Bold
-                            ),
+                                MaterialTheme.typography.titleMedium.copy(
+                                    fontWeight = FontWeight.Bold
+                                ),
                             color = Secondary,
                             fontSize = 16.sp
                         )
@@ -187,11 +245,11 @@ fun ParrotContent(state: ParrotState, modifier: Modifier = Modifier) {
                     // きおくできるじかん
                     Row(
                         modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .clip(Shapes.large)
-                            .background(MaterialTheme.colorScheme.background)
-                            .padding(horizontal = 12.dp, vertical = 10.dp),
+                            Modifier
+                                .fillMaxWidth()
+                                .clip(Shapes.large)
+                                .background(MaterialTheme.colorScheme.background)
+                                .padding(horizontal = 12.dp, vertical = 10.dp),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -204,9 +262,9 @@ fun ParrotContent(state: ParrotState, modifier: Modifier = Modifier) {
                         Text(
                             text = "${state.parrot.memoryTimeHours}じかん",
                             style =
-                            MaterialTheme.typography.titleMedium.copy(
-                                fontWeight = FontWeight.Bold
-                            ),
+                                MaterialTheme.typography.titleMedium.copy(
+                                    fontWeight = FontWeight.Bold
+                                ),
                             color = Secondary,
                             fontSize = 16.sp
                         )

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ParrotContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ParrotContent.kt
@@ -51,30 +51,27 @@ import reminderparrot.composeapp.generated.resources.reminko
  * @param modifier 修飾子
  */
 @Composable
-fun ParrotContent(
-    state: ParrotState,
-    modifier: Modifier = Modifier
-) {
+fun ParrotContent(state: ParrotState, modifier: Modifier = Modifier) {
     Card(
         modifier =
-            modifier
-                .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 8.dp),
+        modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 8.dp),
         shape = Shapes.extraLarge,
         colors =
-            CardDefaults.cardColors(
-                containerColor = White
-            ),
+        CardDefaults.cardColors(
+            containerColor = White
+        ),
         elevation =
-            CardDefaults.cardElevation(
-                defaultElevation = 4.dp
-            )
+        CardDefaults.cardElevation(
+            defaultElevation = 4.dp
+        )
     ) {
         Row(
             modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
+            Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
             horizontalArrangement = Arrangement.spacedBy(20.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -86,10 +83,10 @@ fun ParrotContent(
                 Text(
                     text = "レベル${state.parrot.level}",
                     style =
-                        MaterialTheme.typography.labelMedium.copy(
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 16.sp
-                        ),
+                    MaterialTheme.typography.labelMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 16.sp
+                    ),
                     color = Secondary
                 )
                 // インコと丸型経験値インジケータ
@@ -142,11 +139,11 @@ fun ParrotContent(
                     val animatedProgress by animateFloatAsState(
                         targetValue = displayProgress,
                         animationSpec =
-                            if (skipAnimation) {
-                                tween(durationMillis = 0) // 即座に変更
-                            } else {
-                                tween(durationMillis = 1000) // 通常のアニメーション
-                            },
+                        if (skipAnimation) {
+                            tween(durationMillis = 0) // 即座に変更
+                        } else {
+                            tween(durationMillis = 1000) // 通常のアニメーション
+                        },
                         label = "experience_progress"
                     )
 
@@ -174,10 +171,10 @@ fun ParrotContent(
                                 sweepAngle = 360f * animatedProgress,
                                 useCenter = false,
                                 topLeft =
-                                    Offset(
-                                        center.x - radius,
-                                        center.y - radius
-                                    ),
+                                Offset(
+                                    center.x - radius,
+                                    center.y - radius
+                                ),
                                 size = Size(radius * 2, radius * 2),
                                 style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
                             )
@@ -203,10 +200,10 @@ fun ParrotContent(
                 Text(
                     text = "できること",
                     style =
-                        MaterialTheme.typography.titleMedium.copy(
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 16.sp
-                        ),
+                    MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 16.sp
+                    ),
                     color = Secondary
                 )
 
@@ -217,11 +214,11 @@ fun ParrotContent(
                     // おぼえられることば
                     Row(
                         modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clip(Shapes.large)
-                                .background(MaterialTheme.colorScheme.background)
-                                .padding(horizontal = 12.dp, vertical = 10.dp),
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(Shapes.large)
+                            .background(MaterialTheme.colorScheme.background)
+                            .padding(horizontal = 12.dp, vertical = 10.dp),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -234,9 +231,9 @@ fun ParrotContent(
                         Text(
                             text = "${state.parrot.memorizedWords}こ",
                             style =
-                                MaterialTheme.typography.titleMedium.copy(
-                                    fontWeight = FontWeight.Bold
-                                ),
+                            MaterialTheme.typography.titleMedium.copy(
+                                fontWeight = FontWeight.Bold
+                            ),
                             color = Secondary,
                             fontSize = 16.sp
                         )
@@ -245,11 +242,11 @@ fun ParrotContent(
                     // きおくじかん
                     Row(
                         modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clip(Shapes.large)
-                                .background(MaterialTheme.colorScheme.background)
-                                .padding(horizontal = 12.dp, vertical = 10.dp),
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(Shapes.large)
+                            .background(MaterialTheme.colorScheme.background)
+                            .padding(horizontal = 12.dp, vertical = 10.dp),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
@@ -262,9 +259,9 @@ fun ParrotContent(
                         Text(
                             text = "${state.parrot.memoryTimeHours}じかん",
                             style =
-                                MaterialTheme.typography.titleMedium.copy(
-                                    fontWeight = FontWeight.Bold
-                                ),
+                            MaterialTheme.typography.titleMedium.copy(
+                                fontWeight = FontWeight.Bold
+                            ),
                             color = Secondary,
                             fontSize = 16.sp
                         )

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ParrotContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ParrotContent.kt
@@ -242,7 +242,7 @@ fun ParrotContent(
                         )
                     }
 
-                    // きおくできるじかん
+                    // きおくじかん
                     Row(
                         modifier =
                             Modifier
@@ -254,7 +254,7 @@ fun ParrotContent(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = "きおくできるじかん",
+                            text = "きおくじかん",
                             style = MaterialTheme.typography.bodyMedium,
                             color = Gray,
                             fontSize = 13.sp

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
@@ -110,9 +110,9 @@ fun ReminderContent(
                 isShowBottomSheet = true
             },
             modifier =
-                Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(16.dp)
+            Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp)
         )
 
         // リマインダー追加用ボトムシート
@@ -143,10 +143,7 @@ fun ReminderContent(
  * リマインダー用フローティングアクションボタン
  */
 @Composable
-private fun ReminderFloatingActionButton(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
+private fun ReminderFloatingActionButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
     FloatingActionButton(
         onClick = onClick,
         containerColor = ParrotYellow,
@@ -184,10 +181,10 @@ private fun ReminderItems(
         else -> {
             LazyColumn(
                 modifier =
-                    modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.background)
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
             ) {
                 items(state.reminders) { reminder ->
                     ReminderCard(
@@ -206,28 +203,24 @@ private fun ReminderItems(
  * 個々のリマインダーを表示するカードコンポーネント
  */
 @Composable
-private fun ReminderCard(
-    reminder: Reminder,
-    onToggleCompletion: () -> Unit,
-    modifier: Modifier = Modifier
-) {
+private fun ReminderCard(reminder: Reminder, onToggleCompletion: () -> Unit, modifier: Modifier = Modifier) {
     Card(
         modifier = modifier.fillMaxWidth(),
         colors =
-            CardDefaults.cardColors(
-                containerColor = White
-            ),
+        CardDefaults.cardColors(
+            containerColor = White
+        ),
         shape = Shapes.extraLarge,
         elevation =
-            CardDefaults.cardElevation(
-                defaultElevation = 4.dp
-            )
+        CardDefaults.cardElevation(
+            defaultElevation = 4.dp
+        )
     ) {
         Row(
             modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
+            Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -255,11 +248,7 @@ private fun ReminderCard(
  * 円形のチェックボックス
  */
 @Composable
-private fun CircularCheckbox(
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier
-) {
+private fun CircularCheckbox(checked: Boolean, onCheckedChange: (Boolean) -> Unit, modifier: Modifier = Modifier) {
     val scale by animateFloatAsState(
         targetValue = if (checked) 0.9f else 0f,
         label = "checkmark_scale"
@@ -267,16 +256,16 @@ private fun CircularCheckbox(
 
     Box(
         modifier =
-            modifier
-                .clip(CircleShape)
-                .border(
-                    width = 2.dp,
-                    color = Secondary,
-                    shape = CircleShape
-                ).background(
-                    color = if (checked) Secondary else White,
-                    shape = CircleShape
-                ).clickable { onCheckedChange(!checked) },
+        modifier
+            .clip(CircleShape)
+            .border(
+                width = 2.dp,
+                color = Secondary,
+                shape = CircleShape
+            ).background(
+                color = if (checked) Secondary else White,
+                shape = CircleShape
+            ).clickable { onCheckedChange(!checked) },
         contentAlignment = Alignment.Center
     ) {
         if (checked) {
@@ -285,9 +274,9 @@ private fun CircularCheckbox(
                 contentDescription = "Checked",
                 tint = White,
                 modifier =
-                    Modifier
-                        .size(20.dp)
-                        .scale(scale)
+                Modifier
+                    .size(20.dp)
+                    .scale(scale)
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
@@ -110,9 +110,9 @@ fun ReminderContent(
                 isShowBottomSheet = true
             },
             modifier =
-            Modifier
-                .align(Alignment.BottomEnd)
-                .padding(16.dp)
+                Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp)
         )
 
         // リマインダー追加用ボトムシート
@@ -143,7 +143,10 @@ fun ReminderContent(
  * リマインダー用フローティングアクションボタン
  */
 @Composable
-private fun ReminderFloatingActionButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
+private fun ReminderFloatingActionButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     FloatingActionButton(
         onClick = onClick,
         containerColor = ParrotYellow,
@@ -176,14 +179,15 @@ private fun ReminderItems(
             ErrorState(state.error, modifier = modifier)
         }
         state.reminders.isEmpty() -> {
-            EmptyState("まだおぼえることはないみたいね", modifier = modifier)
+            EmptyState("なにもおぼえていないよ", modifier = modifier)
         }
         else -> {
             LazyColumn(
-                modifier = modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                modifier =
+                    modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.background)
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
             ) {
                 items(state.reminders) { reminder ->
                     ReminderCard(
@@ -202,21 +206,28 @@ private fun ReminderItems(
  * 個々のリマインダーを表示するカードコンポーネント
  */
 @Composable
-private fun ReminderCard(reminder: Reminder, onToggleCompletion: () -> Unit, modifier: Modifier = Modifier) {
+private fun ReminderCard(
+    reminder: Reminder,
+    onToggleCompletion: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     Card(
         modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = White
-        ),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = White
+            ),
         shape = Shapes.extraLarge,
-        elevation = CardDefaults.cardElevation(
-            defaultElevation = 4.dp
-        )
+        elevation =
+            CardDefaults.cardElevation(
+                defaultElevation = 4.dp
+            )
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -244,25 +255,28 @@ private fun ReminderCard(reminder: Reminder, onToggleCompletion: () -> Unit, mod
  * 円形のチェックボックス
  */
 @Composable
-private fun CircularCheckbox(checked: Boolean, onCheckedChange: (Boolean) -> Unit, modifier: Modifier = Modifier) {
+private fun CircularCheckbox(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
     val scale by animateFloatAsState(
         targetValue = if (checked) 0.9f else 0f,
         label = "checkmark_scale"
     )
 
     Box(
-        modifier = modifier
-            .clip(CircleShape)
-            .border(
-                width = 2.dp,
-                color = Secondary,
-                shape = CircleShape
-            )
-            .background(
-                color = if (checked) Secondary else White,
-                shape = CircleShape
-            )
-            .clickable { onCheckedChange(!checked) },
+        modifier =
+            modifier
+                .clip(CircleShape)
+                .border(
+                    width = 2.dp,
+                    color = Secondary,
+                    shape = CircleShape
+                ).background(
+                    color = if (checked) Secondary else White,
+                    shape = CircleShape
+                ).clickable { onCheckedChange(!checked) },
         contentAlignment = Alignment.Center
     ) {
         if (checked) {
@@ -270,9 +284,10 @@ private fun CircularCheckbox(checked: Boolean, onCheckedChange: (Boolean) -> Uni
                 imageVector = Icons.Default.Check,
                 contentDescription = "Checked",
                 tint = White,
-                modifier = Modifier
-                    .size(20.dp)
-                    .scale(scale)
+                modifier =
+                    Modifier
+                        .size(20.dp)
+                        .scale(scale)
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
@@ -74,7 +74,11 @@ fun HomeScreen(
             // リマインダーコンテンツ
             ReminderContent(
                 state = state,
-                onToggleCompletion = reminderListViewModel::toggleReminderCompletion,
+                onToggleCompletion = { reminderId ->
+                    reminderListViewModel.toggleReminderCompletion(reminderId)
+                    // リマインダー完了後にインコの状態を再読み込み
+                    parrotViewModel.loadParrot()
+                },
                 onCreateReminder = { text ->
                     reminderListViewModel.createReminder(text)
                     // リマインダー作成後にインコの状態を再読み込み

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
@@ -54,6 +54,8 @@ fun HomeScreen(
             onToggleCompletion = reminderListViewModel::toggleReminderCompletion,
             onCreateReminder = { text ->
                 reminderListViewModel.createReminder(text)
+                // リマインダー作成後にインコの状態を再読み込み
+                parrotViewModel.loadParrot()
             },
             modifier =
             Modifier

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
@@ -1,20 +1,27 @@
 package com.maropiyo.reminderparrot.ui.screens
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.maropiyo.reminderparrot.presentation.viewmodel.ParrotViewModel
 import com.maropiyo.reminderparrot.presentation.viewmodel.ReminderListViewModel
+import com.maropiyo.reminderparrot.ui.components.home.LevelUpDialog
 import com.maropiyo.reminderparrot.ui.components.home.ParrotContent
 import com.maropiyo.reminderparrot.ui.components.home.ReminderContent
+import kotlinx.coroutines.delay
 import org.koin.compose.viewmodel.koinViewModel
 
 /**
@@ -35,32 +42,55 @@ fun HomeScreen(
     val parrotState by parrotViewModel.state.collectAsState()
     val state by reminderListViewModel.state.collectAsState()
 
-    Column(
-        modifier =
-        modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        // Parrotコンテンツ
-        ParrotContent(
-            state = parrotState,
-            modifier = Modifier.fillMaxWidth()
-        )
+    // レベルアップポップアップの表示状態
+    var showLevelUpPopup by remember { mutableStateOf(false) }
+    var previousLevel by remember { mutableStateOf(parrotState.parrot.level) }
 
-        // リマインダーコンテンツ
-        ReminderContent(
-            state = state,
-            onToggleCompletion = reminderListViewModel::toggleReminderCompletion,
-            onCreateReminder = { text ->
-                reminderListViewModel.createReminder(text)
-                // リマインダー作成後にインコの状態を再読み込み
-                parrotViewModel.loadParrot()
-            },
-            modifier =
-            Modifier
-                .fillMaxWidth()
-                .weight(1f)
+    // レベルアップを検出
+    LaunchedEffect(parrotState.parrot.level) {
+        if (parrotState.parrot.level > previousLevel) {
+            // 経験値ゲージのアニメーション完了を待つ
+            delay(1000)
+
+            // レベルアップポップアップを表示
+            showLevelUpPopup = true
+            previousLevel = parrotState.parrot.level
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Parrotコンテンツ
+            ParrotContent(
+                state = parrotState,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            // リマインダーコンテンツ
+            ReminderContent(
+                state = state,
+                onToggleCompletion = reminderListViewModel::toggleReminderCompletion,
+                onCreateReminder = { text ->
+                    reminderListViewModel.createReminder(text)
+                    // リマインダー作成後にインコの状態を再読み込み
+                    parrotViewModel.loadParrot()
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+            )
+        }
+
+        // レベルアップダイアログ（画面全体をマスク）
+        LevelUpDialog(
+            isVisible = showLevelUpPopup,
+            parrot = parrotState.parrot,
+            onDismiss = { showLevelUpPopup = false }
         )
     }
 }

--- a/composeApp/src/commonMain/sqldelight/com/maropiyo/reminderparrot/db/ReminderParrotDatabase.sq
+++ b/composeApp/src/commonMain/sqldelight/com/maropiyo/reminderparrot/db/ReminderParrotDatabase.sq
@@ -19,3 +19,30 @@ WHERE id = ?;
 
 removeAllReminders:
 DELETE FROM Reminder;
+
+-- Parrotテーブルの定義
+CREATE TABLE Parrot (
+    id INTEGER PRIMARY KEY DEFAULT 1,
+    level INTEGER NOT NULL DEFAULT 1,
+    current_experience INTEGER NOT NULL DEFAULT 0,
+    max_experience INTEGER NOT NULL DEFAULT 1,
+    memorized_words INTEGER NOT NULL DEFAULT 1,
+    memory_time_hours INTEGER NOT NULL DEFAULT 1
+);
+
+-- インコデータの取得（単一レコードのみ存在）
+selectParrot:
+SELECT Parrot.*
+FROM Parrot
+WHERE id = 1;
+
+-- インコデータの挿入（初回のみ）
+insertParrot:
+INSERT OR REPLACE INTO Parrot(id, level, current_experience, max_experience, memorized_words, memory_time_hours)
+VALUES(1, ?, ?, ?, ?, ?);
+
+-- インコデータの更新
+updateParrot:
+UPDATE Parrot
+SET level = ?, current_experience = ?, max_experience = ?, memorized_words = ?, memory_time_hours = ?
+WHERE id = 1;


### PR DESCRIPTION
## Summary
レベルアップ時のお祝いダイアログ機能とリマインダー完了時の経験値追加機能を実装

### 🎯 主要機能
- **レベルアップダイアログ**: 経験値ゲージアニメーション完了時に盛大なお祝い表示
- **リマインダー完了時経験値**: 完了チェック時に+1経験値を付与
- **デザイン統一**: ElevatedButtonを使用してプロジェクト全体のボタンスタイルと統一

### 🚀 実装内容

#### レベルアップダイアログ
- BasicAlertDialogを使用して画面全体をマスク
- reminko_jump.pngを使った回転アニメーション
- レベル情報と能力向上の詳細表示（覚えられることば・記憶時間）
- 「やったー！」ボタンでユーザーが能動的に閉じる仕様
- 「かしこくなったよ！」というパロットらしい表現

#### 経験値システムの拡張
- リマインダー追加時: +1経験値
- リマインダー完了時: +1経験値（新機能）
- 完了状態になった場合のみ経験値を付与する条件分岐

#### UI/UXの改善
- ダイアログ幅を適切に調整し視認性を向上
- 改行問題を修正（maxLines = 1）
- プロジェクト全体のデザイン一貫性を保持

### 🔧 技術詳細
- **HomeScreen.kt**: レベルアップ検知とダイアログ表示を実装
- **LevelUpPopup.kt**: Material3 BasicAlertDialogを使用したダイアログコンポーネント
- **ReminderListViewModel.kt**: リマインダー完了時の経験値追加ロジック
- **ParrotContent.kt**: 経験値ゲージアニメーションとの連携

### 📱 ユーザー体験
1. リマインダー追加・完了で経験値獲得
2. 経験値ゲージがスムーズにアニメーション
3. レベルアップ時に盛大なお祝いダイアログ
4. インコが喜ぶアニメーションで達成感を演出

## Test plan
- [ ] リマインダー追加時の経験値増加を確認
- [ ] リマインダー完了時の経験値増加を確認
- [ ] レベルアップダイアログの表示とアニメーションを確認
- [ ] ダイアログのボタン操作（タップ・バックキー・外側タップ）を確認
- [ ] Android/iOSでの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)