### PR TITLE
feat(parrot): インコのレベルに応じたリマインダー数制限機能

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import com.maropiyo.reminderparrot.domain.entity.Reminder
+import com.maropiyo.reminderparrot.presentation.state.ParrotState
 import com.maropiyo.reminderparrot.presentation.state.ReminderListState
 import com.maropiyo.reminderparrot.ui.components.state.EmptyState
 import com.maropiyo.reminderparrot.ui.components.state.ErrorState
@@ -60,6 +61,7 @@ import reminderparrot.composeapp.generated.resources.reminko_face
  * ホーム画面内のリマインダー関連機能を管理するコンポーネント
  *
  * @param state リマインダーリストの状態
+ * @param parrotState インコの状態
  * @param onToggleCompletion リマインダー完了切り替えコールバック
  * @param onCreateReminder 新しいリマインダー作成コールバック
  * @param modifier 修飾子
@@ -68,6 +70,7 @@ import reminderparrot.composeapp.generated.resources.reminko_face
 @Composable
 fun ReminderContent(
     state: ReminderListState,
+    parrotState: ParrotState,
     onToggleCompletion: (String) -> Unit,
     onCreateReminder: suspend (String) -> Unit,
     modifier: Modifier = Modifier
@@ -133,7 +136,9 @@ fun ReminderContent(
                         sheetState.hide()
                     }
                 },
-                sheetState = sheetState
+                sheetState = sheetState,
+                memorizedWords = parrotState.parrot.memorizedWords,
+                currentReminderCount = state.reminders.size
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
@@ -74,6 +74,7 @@ fun HomeScreen(
             // リマインダーコンテンツ
             ReminderContent(
                 state = state,
+                parrotState = parrotState,
                 onToggleCompletion = { reminderId ->
                     reminderListViewModel.toggleReminderCompletion(reminderId)
                     // リマインダー完了後にインコの状態を再読み込み


### PR DESCRIPTION
## Summary
インコのレベル（覚えられることばの数）に応じてリマインダー登録数を制限する機能を実装

### 🎯 機能概要
- インコが覚えられることばの数を超えるリマインダーの追加を制限
- レベルアップを促すメッセージでユーザーのモチベーションを向上
- ゲーミフィケーション要素をさらに強化

### 🚀 実装内容

#### 制限機能の実装
- 現在のリマインダー数が`memorizedWords`以上の場合、新規追加を制限
- `HomeScreen` → `ReminderContent` → `AddReminderBottomSheet`の階層でParrotStateを伝達
- リアルタイムで制限状態をチェック

#### UI/UXの変更（制限時）
- **タイトル**: 「よんだ？」→「もうおぼえられないよ〜」
- **テキストフィールド**: 
  - 入力無効化（グレーアウト）
  - プレースホルダー: 「レベルをあげてもっとかしこくなろう！」
- **保存ボタン**: 無効化

#### 技術的な変更点
1. **HomeScreen.kt**: `ReminderContent`に`parrotState`を渡すように修正
2. **ReminderContent.kt**: `ParrotState`を受け取り、リマインダー数情報を伝達
3. **AddReminderBottomSheet.kt**: 
   - `memorizedWords`と`currentReminderCount`パラメータを追加
   - 制限チェックロジックと条件付きUI表示を実装

### 📱 ユーザー体験
1. レベル1のインコ（3個まで）→ 4個目を登録しようとすると制限
2. 「もうおぼえられないよ〜」というインコらしいメッセージ
3. レベルアップへの動機付けメッセージ
4. リマインダーを完了させてレベルアップすると、より多く登録可能に

### 🎮 ゲーミフィケーション効果
- リマインダー完了 → 経験値獲得 → レベルアップ → より多く登録可能
- 成長の実感とモチベーション維持の好循環を創出

## Test plan
- [ ] レベル1（3個まで）でリマインダーを3個登録し、4個目で制限を確認
- [ ] 制限時のメッセージとUI無効化を確認
- [ ] リマインダー完了でレベルアップ後、追加登録可能を確認
- [ ] 各レベルでの制限数が正しく適用されることを確認
- [ ] Android/iOSでの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)