### PR TITLE
feat(reminder): リマインダー編集・削除機能を実装

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/local/ReminderLocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/local/ReminderLocalDataSource.kt
@@ -47,4 +47,13 @@ class ReminderLocalDataSource(
             id = reminder.id
         )
     }
+
+    /**
+     * リマインダーを削除する
+     *
+     * @param reminderId 削除するリマインダーのID
+     */
+    fun deleteReminder(reminderId: String) {
+        database.reminderParrotDatabaseQueries.deleteReminder(reminderId)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/repository/ReminderRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/repository/ReminderRepositoryImpl.kt
@@ -53,4 +53,18 @@ class ReminderRepositoryImpl(
     } catch (e: Exception) {
         Result.failure(e)
     }
+
+    /**
+     * リマインダーを削除する
+     *
+     * @param reminderId 削除するリマインダーのID
+     * @return 削除結果
+     * @throws Exception リマインダーの削除に失敗した場合
+     */
+    override suspend fun deleteReminder(reminderId: String): Result<Unit> = try {
+        localDataSource.deleteReminder(reminderId)
+        Result.success(Unit)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
@@ -11,6 +11,7 @@ import com.maropiyo.reminderparrot.domain.repository.ParrotRepository
 import com.maropiyo.reminderparrot.domain.repository.ReminderRepository
 import com.maropiyo.reminderparrot.domain.usecase.AddParrotExperienceUseCase
 import com.maropiyo.reminderparrot.domain.usecase.CreateReminderUseCase
+import com.maropiyo.reminderparrot.domain.usecase.DeleteReminderUseCase
 import com.maropiyo.reminderparrot.domain.usecase.GetParrotUseCase
 import com.maropiyo.reminderparrot.domain.usecase.GetRemindersUseCase
 import com.maropiyo.reminderparrot.domain.usecase.UpdateReminderUseCase
@@ -24,13 +25,14 @@ import org.koin.dsl.module
 val appModule =
     module {
         // ViewModel
-        single<ReminderListViewModel> { ReminderListViewModel(get(), get(), get(), get()) }
+        single<ReminderListViewModel> { ReminderListViewModel(get(), get(), get(), get(), get()) }
         single<ParrotViewModel> { ParrotViewModel(get()) }
 
         // UseCase
         single<CreateReminderUseCase> { CreateReminderUseCase(get(), get()) }
         single<GetRemindersUseCase> { GetRemindersUseCase(get()) }
         single<UpdateReminderUseCase> { UpdateReminderUseCase(get()) }
+        single<DeleteReminderUseCase> { DeleteReminderUseCase(get()) }
         single<GetParrotUseCase> { GetParrotUseCase(get()) }
         single<AddParrotExperienceUseCase> { AddParrotExperienceUseCase(get()) }
 

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/repository/ReminderRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/repository/ReminderRepository.kt
@@ -28,4 +28,12 @@ interface ReminderRepository {
      * @return 更新結果
      */
     suspend fun updateReminder(reminder: Reminder): Result<Unit>
+
+    /**
+     * リマインダーを削除する
+     *
+     * @param reminderId 削除するリマインダーのID
+     * @return 削除結果
+     */
+    suspend fun deleteReminder(reminderId: String): Result<Unit>
 }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/DeleteReminderUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/DeleteReminderUseCase.kt
@@ -1,0 +1,20 @@
+package com.maropiyo.reminderparrot.domain.usecase
+
+import com.maropiyo.reminderparrot.domain.repository.ReminderRepository
+
+/**
+ * リマインダーを削除するユースケース
+ *
+ * @property reminderRepository リマインダーリポジトリ
+ */
+class DeleteReminderUseCase(
+    private val reminderRepository: ReminderRepository
+) {
+    /**
+     * リマインダーを削除する
+     *
+     * @param reminderId 削除するリマインダーのID
+     * @return 削除結果
+     */
+    suspend operator fun invoke(reminderId: String): Result<Unit> = reminderRepository.deleteReminder(reminderId)
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/EditReminderBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/EditReminderBottomSheet.kt
@@ -1,0 +1,321 @@
+package com.maropiyo.reminderparrot.ui.components.home
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.maropiyo.reminderparrot.domain.entity.Reminder
+import com.maropiyo.reminderparrot.ui.theme.Background
+import com.maropiyo.reminderparrot.ui.theme.DisableSecondary
+import com.maropiyo.reminderparrot.ui.theme.Error
+import com.maropiyo.reminderparrot.ui.theme.Secondary
+import com.maropiyo.reminderparrot.ui.theme.Shapes
+import com.maropiyo.reminderparrot.ui.theme.White
+import org.jetbrains.compose.resources.painterResource
+import reminderparrot.composeapp.generated.resources.Res
+import reminderparrot.composeapp.generated.resources.reminko_raising_hand
+
+/**
+ * リマインダー編集ボトムシート
+ *
+ * @param reminder 編集対象のリマインダー
+ * @param onDismiss ボトムシートが閉じられたときのコールバック
+ * @param onUpdateReminder リマインダーが更新されたときのコールバック
+ * @param onDeleteReminder リマインダーが削除されたときのコールバック
+ * @param sheetState ボトムシートの状態
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditReminderBottomSheet(
+    reminder: Reminder,
+    onDismiss: () -> Unit,
+    onUpdateReminder: (String) -> Unit,
+    onDeleteReminder: () -> Unit,
+    sheetState: androidx.compose.material3.SheetState
+) {
+    var reminderText by remember { mutableStateOf(reminder.text) }
+
+    ModalBottomSheet(
+        dragHandle = null,
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = Color.Transparent
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 16.dp)
+                    .imePadding()
+        ) {
+            EditReminderInputCard(
+                reminderText = reminderText,
+                onReminderTextChange = { reminderText = it },
+                onUpdateReminder = {
+                    if (reminderText.isNotBlank() && reminderText != reminder.text) {
+                        onUpdateReminder(reminderText)
+                    }
+                },
+                onDeleteReminder = onDeleteReminder,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 104.dp),
+                isUpdateEnabled = reminderText.isNotBlank() && reminderText != reminder.text
+            )
+
+            // リマインコの画像
+            Image(
+                painter = painterResource(Res.drawable.reminko_raising_hand),
+                contentDescription = "Parrot",
+                modifier =
+                    Modifier
+                        .size(128.dp)
+                        .align(Alignment.TopCenter),
+                contentScale = ContentScale.Crop
+            )
+        }
+    }
+}
+
+/**
+ * リマインダー編集入力カード
+ */
+@Composable
+private fun EditReminderInputCard(
+    reminderText: String,
+    onReminderTextChange: (String) -> Unit,
+    onUpdateReminder: () -> Unit,
+    onDeleteReminder: () -> Unit,
+    modifier: Modifier = Modifier,
+    isUpdateEnabled: Boolean
+) {
+    Card(
+        modifier = modifier,
+        colors =
+            CardDefaults.cardColors(
+                containerColor = Background
+            ),
+        shape = Shapes.extraLarge
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 24.dp)
+        ) {
+            // タイトルテキスト
+            Text(
+                text = "どうした？",
+                color = Secondary,
+                style = MaterialTheme.typography.titleLarge
+            )
+
+            Spacer(Modifier.size(16.dp))
+
+            // テキスト入力フィールド
+            EditReminderTextField(
+                reminderText = reminderText,
+                onValueChange = onReminderTextChange,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+            )
+
+            Spacer(Modifier.size(16.dp))
+
+            // ボタンエリア
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+            ) {
+                // わすれるボタン
+                DeleteReminderButton(
+                    onClick = onDeleteReminder,
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .height(50.dp)
+                )
+
+                Spacer(Modifier.width(8.dp))
+
+                // 更新ボタン
+                UpdateReminderButton(
+                    onClick = onUpdateReminder,
+                    enabled = isUpdateEnabled,
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .height(50.dp)
+                )
+            }
+        }
+    }
+}
+
+/**
+ * リマインダー編集テキスト入力フィールド
+ *
+ * @param reminderText リマインダーテキスト
+ * @param onValueChange テキストが変更されたときのコールバック
+ * @param modifier 修飾子
+ */
+@Composable
+private fun EditReminderTextField(
+    reminderText: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // 初期テキストとカーソル位置を保持するための状態
+    var textFieldValue by remember {
+        mutableStateOf(
+            TextFieldValue(
+                text = reminderText,
+                selection = TextRange(reminderText.length)
+            )
+        )
+    }
+
+    // リマインダーテキストが外部から変更された場合に同期
+    LaunchedEffect(reminderText) {
+        if (textFieldValue.text != reminderText) {
+            textFieldValue =
+                TextFieldValue(
+                    text = reminderText,
+                    selection = TextRange(reminderText.length)
+                )
+        }
+    }
+
+    TextField(
+        value = textFieldValue,
+        onValueChange = { changedValue ->
+            textFieldValue = changedValue
+            onValueChange(changedValue.text)
+        },
+        modifier = modifier,
+        colors =
+            TextFieldDefaults.colors(
+                focusedTextColor = Secondary,
+                focusedContainerColor = White,
+                unfocusedContainerColor = White,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent
+            ),
+        textStyle =
+            MaterialTheme.typography.bodyLarge.copy(
+                color = Secondary,
+                fontWeight = FontWeight.Bold
+            ),
+        placeholder =
+            {
+                Text(
+                    text = "あたらしいことばをかいてね",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = Secondary.copy(alpha = 0.5f)
+                )
+            },
+        singleLine = true,
+        shape = Shapes.large
+    )
+}
+
+/**
+ * リマインダー更新ボタン
+ *
+ * @param onClick ボタンがクリックされたときの処理
+ * @param enabled ボタンが有効かどうか
+ * @param modifier ボタンの修飾子
+ */
+@Composable
+private fun UpdateReminderButton(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    modifier: Modifier = Modifier
+) {
+    ElevatedButton(
+        onClick = onClick,
+        modifier = modifier,
+        shape = Shapes.large,
+        colors =
+            ButtonDefaults.elevatedButtonColors(
+                containerColor = Secondary,
+                contentColor = White,
+                disabledContainerColor = DisableSecondary,
+                disabledContentColor = White
+            ),
+        enabled = enabled
+    ) {
+        Text(
+            text = "おぼえなおす",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+/**
+ * リマインダー削除ボタン
+ *
+ * @param onClick ボタンがクリックされたときの処理
+ * @param modifier ボタンの修飾子
+ */
+@Composable
+private fun DeleteReminderButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ElevatedButton(
+        onClick = onClick,
+        modifier = modifier,
+        shape = Shapes.large,
+        colors =
+            ButtonDefaults.elevatedButtonColors(
+                containerColor = Error,
+                contentColor = White
+            )
+    ) {
+        Text(
+            text = "わすれる",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/EditReminderBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/EditReminderBottomSheet.kt
@@ -74,11 +74,11 @@ fun EditReminderBottomSheet(
     ) {
         Box(
             modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .padding(bottom = 16.dp)
-                    .imePadding()
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp)
+                .imePadding()
         ) {
             EditReminderInputCard(
                 reminderText = reminderText,
@@ -90,9 +90,9 @@ fun EditReminderBottomSheet(
                 },
                 onDeleteReminder = onDeleteReminder,
                 modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(top = 104.dp),
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 104.dp),
                 isUpdateEnabled = reminderText.isNotBlank() && reminderText != reminder.text
             )
 
@@ -101,9 +101,9 @@ fun EditReminderBottomSheet(
                 painter = painterResource(Res.drawable.reminko_raising_hand),
                 contentDescription = "Parrot",
                 modifier =
-                    Modifier
-                        .size(128.dp)
-                        .align(Alignment.TopCenter),
+                Modifier
+                    .size(128.dp)
+                    .align(Alignment.TopCenter),
                 contentScale = ContentScale.Crop
             )
         }
@@ -125,17 +125,17 @@ private fun EditReminderInputCard(
     Card(
         modifier = modifier,
         colors =
-            CardDefaults.cardColors(
-                containerColor = Background
-            ),
+        CardDefaults.cardColors(
+            containerColor = Background
+        ),
         shape = Shapes.extraLarge
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 24.dp)
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 24.dp)
         ) {
             // タイトルテキスト
             Text(
@@ -151,9 +151,9 @@ private fun EditReminderInputCard(
                 reminderText = reminderText,
                 onValueChange = onReminderTextChange,
                 modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
             )
 
             Spacer(Modifier.size(16.dp))
@@ -161,17 +161,17 @@ private fun EditReminderInputCard(
             // ボタンエリア
             Row(
                 modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
             ) {
                 // わすれるボタン
                 DeleteReminderButton(
                     onClick = onDeleteReminder,
                     modifier =
-                        Modifier
-                            .weight(1f)
-                            .height(50.dp)
+                    Modifier
+                        .weight(1f)
+                        .height(50.dp)
                 )
 
                 Spacer(Modifier.width(8.dp))
@@ -181,9 +181,9 @@ private fun EditReminderInputCard(
                     onClick = onUpdateReminder,
                     enabled = isUpdateEnabled,
                     modifier =
-                        Modifier
-                            .weight(1f)
-                            .height(50.dp)
+                    Modifier
+                        .weight(1f)
+                        .height(50.dp)
                 )
             }
         }
@@ -232,26 +232,26 @@ private fun EditReminderTextField(
         },
         modifier = modifier,
         colors =
-            TextFieldDefaults.colors(
-                focusedTextColor = Secondary,
-                focusedContainerColor = White,
-                unfocusedContainerColor = White,
-                focusedIndicatorColor = Color.Transparent,
-                unfocusedIndicatorColor = Color.Transparent
-            ),
+        TextFieldDefaults.colors(
+            focusedTextColor = Secondary,
+            focusedContainerColor = White,
+            unfocusedContainerColor = White,
+            focusedIndicatorColor = Color.Transparent,
+            unfocusedIndicatorColor = Color.Transparent
+        ),
         textStyle =
-            MaterialTheme.typography.bodyLarge.copy(
-                color = Secondary,
-                fontWeight = FontWeight.Bold
-            ),
+        MaterialTheme.typography.bodyLarge.copy(
+            color = Secondary,
+            fontWeight = FontWeight.Bold
+        ),
         placeholder =
-            {
-                Text(
-                    text = "あたらしいことばをかいてね",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = Secondary.copy(alpha = 0.5f)
-                )
-            },
+        {
+            Text(
+                text = "あたらしいことばをかいてね",
+                style = MaterialTheme.typography.bodyLarge,
+                color = Secondary.copy(alpha = 0.5f)
+            )
+        },
         singleLine = true,
         shape = Shapes.large
     )
@@ -265,22 +265,18 @@ private fun EditReminderTextField(
  * @param modifier ボタンの修飾子
  */
 @Composable
-private fun UpdateReminderButton(
-    onClick: () -> Unit,
-    enabled: Boolean,
-    modifier: Modifier = Modifier
-) {
+private fun UpdateReminderButton(onClick: () -> Unit, enabled: Boolean, modifier: Modifier = Modifier) {
     ElevatedButton(
         onClick = onClick,
         modifier = modifier,
         shape = Shapes.large,
         colors =
-            ButtonDefaults.elevatedButtonColors(
-                containerColor = Secondary,
-                contentColor = White,
-                disabledContainerColor = DisableSecondary,
-                disabledContentColor = White
-            ),
+        ButtonDefaults.elevatedButtonColors(
+            containerColor = Secondary,
+            contentColor = White,
+            disabledContainerColor = DisableSecondary,
+            disabledContentColor = White
+        ),
         enabled = enabled
     ) {
         Text(
@@ -298,19 +294,16 @@ private fun UpdateReminderButton(
  * @param modifier ボタンの修飾子
  */
 @Composable
-private fun DeleteReminderButton(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
+private fun DeleteReminderButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
     ElevatedButton(
         onClick = onClick,
         modifier = modifier,
         shape = Shapes.large,
         colors =
-            ButtonDefaults.elevatedButtonColors(
-                containerColor = Error,
-                contentColor = White
-            )
+        ButtonDefaults.elevatedButtonColors(
+            containerColor = Error,
+            contentColor = White
+        )
     ) {
         Text(
             text = "わすれる",

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
@@ -85,6 +85,12 @@ fun HomeScreen(
                     // リマインダー作成後にインコの状態を再読み込み
                     parrotViewModel.loadParrot()
                 },
+                onUpdateReminder = { reminderId, newText ->
+                    reminderListViewModel.updateReminderText(reminderId, newText)
+                },
+                onDeleteReminder = { reminderId ->
+                    reminderListViewModel.deleteReminder(reminderId)
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)

--- a/composeApp/src/commonMain/sqldelight/com/maropiyo/reminderparrot/db/ReminderParrotDatabase.sq
+++ b/composeApp/src/commonMain/sqldelight/com/maropiyo/reminderparrot/db/ReminderParrotDatabase.sq
@@ -17,6 +17,10 @@ UPDATE Reminder
 SET text = ?, is_completed = ?
 WHERE id = ?;
 
+deleteReminder:
+DELETE FROM Reminder
+WHERE id = ?;
+
 removeAllReminders:
 DELETE FROM Reminder;
 

--- a/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCaseTest.kt
@@ -54,6 +54,10 @@ class CreateReminderUseCaseTest {
         override suspend fun updateReminder(reminder: Reminder): Result<Unit> {
             return Result.success(Unit)
         }
+
+        override suspend fun deleteReminder(reminderId: String): Result<Unit> {
+            return Result.success(Unit)
+        }
     }
 
     /**

--- a/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/GetRemindersUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/GetRemindersUseCaseTest.kt
@@ -53,6 +53,10 @@ class GetRemindersUseCaseTest {
         override suspend fun updateReminder(reminder: Reminder): Result<Unit> {
             return Result.success(Unit)
         }
+
+        override suspend fun deleteReminder(reminderId: String): Result<Unit> {
+            return Result.success(Unit)
+        }
     }
 
     /**

--- a/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/UpdateReminderUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/UpdateReminderUseCaseTest.kt
@@ -51,6 +51,10 @@ class UpdateReminderUseCaseTest {
                 Result.success(Unit)
             }
         }
+
+        override suspend fun deleteReminder(reminderId: String): Result<Unit> {
+            return Result.success(Unit)
+        }
     }
 
     /**


### PR DESCRIPTION
## 概要
リマインダーの編集と削除機能を実装しました。リマインダーカードをタップすることで、内容の編集や削除ができるようになりました。

## 実装内容

### 機能
- リマインダーカードタップで編集ボトムシートを表示
- テキスト編集機能（「おぼえなおす」ボタン）
- リマインダー削除機能（「わすれる」ボタン）

### 技術的な変更
- `DeleteReminderUseCase`を新規作成
- Repository、DataSourceに`deleteReminder`メソッドを追加
- SQLDelightに`deleteReminder`クエリを追加
- `ReminderListViewModel`に編集・削除メソッドを追加
- `EditReminderBottomSheet`コンポーネントを作成

### UI/UXの改善
- 編集画面は追加画面と同じデザインで統一感を保持
- 自然な日本語表現を使用
  - タイトル: 「どうした？」
  - プレースホルダー: 「あたらしいことばをかいてね」
  - ボタン: 「おぼえなおす」「わすれる」

## スクリーンショット
| 編集画面 | 削除確認 |
|---------|---------|
| リマインダーをタップすると編集画面が表示 | 「わすれる」ボタンで削除可能 |

## テスト項目
- [x] リマインダーカードのタップで編集画面が表示される
- [x] 既存のテキストが編集フィールドに表示される
- [x] テキストを変更して「おぼえなおす」で更新される
- [x] 「わすれる」ボタンでリマインダーが削除される
- [x] 空のテキストでは更新ボタンが無効になる
- [x] 変更がない場合は更新ボタンが無効になる

## 関連Issue
なし

🤖 Generated with [Claude Code](https://claude.ai/code)