### PR TITLE
test: エンティティ変更に伴うテストファイルの修正

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/mapper/ReminderMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/mapper/ReminderMapper.kt
@@ -2,6 +2,7 @@ package com.maropiyo.reminderparrot.data.mapper
 
 import com.maropiyo.reminderparrot.data.model.ReminderDto
 import com.maropiyo.reminderparrot.domain.entity.Reminder
+import kotlinx.datetime.Instant
 
 /**
  * リマインダーのマッパー
@@ -16,7 +17,9 @@ class ReminderMapper {
     fun mapToEntity(dto: ReminderDto): Reminder = Reminder(
         id = dto.id,
         text = dto.text,
-        isCompleted = dto.isCompleted
+        isCompleted = dto.isCompleted,
+        createdAt = Instant.fromEpochMilliseconds(dto.createdAt),
+        forgetAt = Instant.fromEpochMilliseconds(dto.forgetAt)
     )
 
     /**
@@ -28,7 +31,9 @@ class ReminderMapper {
     fun mapToDto(entity: Reminder): ReminderDto = ReminderDto(
         id = entity.id,
         text = entity.text,
-        isCompleted = entity.isCompleted
+        isCompleted = entity.isCompleted,
+        createdAt = entity.createdAt.toEpochMilliseconds(),
+        forgetAt = entity.forgetAt.toEpochMilliseconds()
     )
 
     /**
@@ -37,11 +42,16 @@ class ReminderMapper {
      * @param id リマインダーID
      * @param text リマインダーテキスト
      * @param isCompleted 完了フラグ
+     * @param createdAt 作成日時（エポックミリ秒）
+     * @param forgetAt 忘却日時（エポックミリ秒）
      * @return リマインダー
      */
-    fun mapFromDatabase(id: String, text: String, isCompleted: Long): Reminder = Reminder(
-        id = id,
-        text = text,
-        isCompleted = isCompleted == 1L
-    )
+    fun mapFromDatabase(id: String, text: String, isCompleted: Long, createdAt: Long, forgetAt: Long): Reminder =
+        Reminder(
+            id = id,
+            text = text,
+            isCompleted = isCompleted == 1L,
+            createdAt = Instant.fromEpochMilliseconds(createdAt),
+            forgetAt = Instant.fromEpochMilliseconds(forgetAt)
+        )
 }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/model/ReminderDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/model/ReminderDto.kt
@@ -9,6 +9,8 @@ import kotlinx.serialization.Serializable
  * @property id リマインダーID
  * @property text リマインダーテキスト
  * @property isCompleted 完了フラグ
+ * @property createdAt 作成日時（エポックミリ秒）
+ * @property forgetAt 忘却日時（エポックミリ秒）
  */
 @Serializable
 data class ReminderDto(
@@ -17,5 +19,9 @@ data class ReminderDto(
     @SerialName("text")
     val text: String,
     @SerialName("is_completed")
-    val isCompleted: Boolean = false
+    val isCompleted: Boolean = false,
+    @SerialName("created_at")
+    val createdAt: Long,
+    @SerialName("forget_at")
+    val forgetAt: Long
 )

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/repository/ReminderRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/repository/ReminderRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.maropiyo.reminderparrot.data.local.ReminderLocalDataSource
 import com.maropiyo.reminderparrot.data.remote.ReminderRemoteDataSource
 import com.maropiyo.reminderparrot.domain.entity.Reminder
 import com.maropiyo.reminderparrot.domain.repository.ReminderRepository
+import kotlinx.datetime.Instant
 
 /**
  * リマインダーリポジトリの実装
@@ -66,5 +67,15 @@ class ReminderRepositoryImpl(
         Result.success(Unit)
     } catch (e: Exception) {
         Result.failure(e)
+    }
+
+    /**
+     * 期限切れリマインダーを削除する
+     *
+     * @param currentTime 現在時刻
+     * @return 削除されたリマインダー数
+     */
+    override suspend fun deleteExpiredReminders(currentTime: Instant): Int {
+        return localDataSource.deleteExpiredReminders(currentTime)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
@@ -11,6 +11,7 @@ import com.maropiyo.reminderparrot.domain.repository.ParrotRepository
 import com.maropiyo.reminderparrot.domain.repository.ReminderRepository
 import com.maropiyo.reminderparrot.domain.usecase.AddParrotExperienceUseCase
 import com.maropiyo.reminderparrot.domain.usecase.CreateReminderUseCase
+import com.maropiyo.reminderparrot.domain.usecase.DeleteExpiredRemindersUseCase
 import com.maropiyo.reminderparrot.domain.usecase.DeleteReminderUseCase
 import com.maropiyo.reminderparrot.domain.usecase.GetParrotUseCase
 import com.maropiyo.reminderparrot.domain.usecase.GetRemindersUseCase
@@ -25,14 +26,15 @@ import org.koin.dsl.module
 val appModule =
     module {
         // ViewModel
-        single<ReminderListViewModel> { ReminderListViewModel(get(), get(), get(), get(), get()) }
+        single<ReminderListViewModel> { ReminderListViewModel(get(), get(), get(), get(), get(), get()) }
         single<ParrotViewModel> { ParrotViewModel(get()) }
 
         // UseCase
-        single<CreateReminderUseCase> { CreateReminderUseCase(get(), get()) }
+        single<CreateReminderUseCase> { CreateReminderUseCase(get(), get(), get()) }
         single<GetRemindersUseCase> { GetRemindersUseCase(get()) }
         single<UpdateReminderUseCase> { UpdateReminderUseCase(get()) }
         single<DeleteReminderUseCase> { DeleteReminderUseCase(get()) }
+        single<DeleteExpiredRemindersUseCase> { DeleteExpiredRemindersUseCase(get()) }
         single<GetParrotUseCase> { GetParrotUseCase(get()) }
         single<AddParrotExperienceUseCase> { AddParrotExperienceUseCase(get()) }
 

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/entity/Reminder.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/entity/Reminder.kt
@@ -1,14 +1,20 @@
 package com.maropiyo.reminderparrot.domain.entity
 
+import kotlinx.datetime.Instant
+
 /**
  * リマインダー
  *
  * @param id リマインダーID
  * @param text リマインダーテキスト
  * @param isCompleted 完了フラグ
+ * @param createdAt 作成日時
+ * @param forgetAt 忘却日時
  */
 data class Reminder(
     val id: String,
     val text: String,
-    val isCompleted: Boolean = false
+    val isCompleted: Boolean = false,
+    val createdAt: Instant,
+    val forgetAt: Instant
 )

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/repository/ReminderRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/repository/ReminderRepository.kt
@@ -1,6 +1,7 @@
 package com.maropiyo.reminderparrot.domain.repository
 
 import com.maropiyo.reminderparrot.domain.entity.Reminder
+import kotlinx.datetime.Instant
 
 /**
  * リマインダーリポジトリ
@@ -36,4 +37,12 @@ interface ReminderRepository {
      * @return 削除結果
      */
     suspend fun deleteReminder(reminderId: String): Result<Unit>
+
+    /**
+     * 期限切れリマインダーを削除する
+     *
+     * @param currentTime 現在時刻
+     * @return 削除されたリマインダー数
+     */
+    suspend fun deleteExpiredReminders(currentTime: Instant): Int
 }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCase.kt
@@ -4,8 +4,8 @@ import com.maropiyo.reminderparrot.domain.common.UuidGenerator
 import com.maropiyo.reminderparrot.domain.entity.Reminder
 import com.maropiyo.reminderparrot.domain.repository.ParrotRepository
 import com.maropiyo.reminderparrot.domain.repository.ReminderRepository
-import kotlin.time.Duration.Companion.hours
 import kotlinx.datetime.Clock
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * リマインダー作成ユースケース
@@ -35,14 +35,15 @@ class CreateReminderUseCase(
 
             val parrot = parrotResult.getOrThrow()
             val currentTime = Clock.System.now()
-            val forgetTime = currentTime + parrot.memoryTimeHours.hours
+            val forgetTime = currentTime + 70.seconds
 
-            val reminder = Reminder(
-                id = uuidGenerator.generateId(),
-                text = text,
-                createdAt = currentTime,
-                forgetAt = forgetTime
-            )
+            val reminder =
+                Reminder(
+                    id = uuidGenerator.generateId(),
+                    text = text,
+                    createdAt = currentTime,
+                    forgetAt = forgetTime
+                )
 
             reminderRepository.createReminder(reminder)
         } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCase.kt
@@ -35,7 +35,7 @@ class CreateReminderUseCase(
 
             val parrot = parrotResult.getOrThrow()
             val currentTime = Clock.System.now()
-            val forgetTime = currentTime + 70.seconds
+            val forgetTime = currentTime + parrot.memoryTimeHours.seconds
 
             val reminder =
                 Reminder(

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCase.kt
@@ -5,7 +5,7 @@ import com.maropiyo.reminderparrot.domain.entity.Reminder
 import com.maropiyo.reminderparrot.domain.repository.ParrotRepository
 import com.maropiyo.reminderparrot.domain.repository.ReminderRepository
 import kotlinx.datetime.Clock
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.hours
 
 /**
  * リマインダー作成ユースケース
@@ -35,7 +35,7 @@ class CreateReminderUseCase(
 
             val parrot = parrotResult.getOrThrow()
             val currentTime = Clock.System.now()
-            val forgetTime = currentTime + parrot.memoryTimeHours.seconds
+            val forgetTime = currentTime + parrot.memoryTimeHours.hours
 
             val reminder =
                 Reminder(

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCase.kt
@@ -2,16 +2,21 @@ package com.maropiyo.reminderparrot.domain.usecase
 
 import com.maropiyo.reminderparrot.domain.common.UuidGenerator
 import com.maropiyo.reminderparrot.domain.entity.Reminder
+import com.maropiyo.reminderparrot.domain.repository.ParrotRepository
 import com.maropiyo.reminderparrot.domain.repository.ReminderRepository
+import kotlin.time.Duration.Companion.hours
+import kotlinx.datetime.Clock
 
 /**
  * リマインダー作成ユースケース
  *
  * @property reminderRepository リマインダーリポジトリ
+ * @property parrotRepository パロットリポジトリ
  * @property uuidGenerator UUIDジェネレーター
  */
 class CreateReminderUseCase(
     private val reminderRepository: ReminderRepository,
+    private val parrotRepository: ParrotRepository,
     private val uuidGenerator: UuidGenerator
 ) {
     /**
@@ -21,12 +26,27 @@ class CreateReminderUseCase(
      * @return 作成したリマインダー
      */
     suspend operator fun invoke(text: String): Result<Reminder> {
-        val reminder =
-            Reminder(
+        return try {
+            // インコの記憶時間を取得
+            val parrotResult = parrotRepository.getParrot()
+            if (parrotResult.isFailure) {
+                return Result.failure(parrotResult.exceptionOrNull()!!)
+            }
+
+            val parrot = parrotResult.getOrThrow()
+            val currentTime = Clock.System.now()
+            val forgetTime = currentTime + parrot.memoryTimeHours.hours
+
+            val reminder = Reminder(
                 id = uuidGenerator.generateId(),
-                text = text
+                text = text,
+                createdAt = currentTime,
+                forgetAt = forgetTime
             )
 
-        return reminderRepository.createReminder(reminder)
+            reminderRepository.createReminder(reminder)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/DeleteExpiredRemindersUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/DeleteExpiredRemindersUseCase.kt
@@ -1,0 +1,28 @@
+package com.maropiyo.reminderparrot.domain.usecase
+
+import com.maropiyo.reminderparrot.domain.repository.ReminderRepository
+import kotlinx.datetime.Clock
+
+/**
+ * 期限切れリマインダー削除UseCase
+ *
+ * インコが忘れる時間を経過したリマインダーを自動削除する
+ */
+class DeleteExpiredRemindersUseCase(
+    private val reminderRepository: ReminderRepository
+) {
+    /**
+     * 期限切れリマインダーを削除する
+     *
+     * @return 削除されたリマインダー数
+     */
+    suspend fun execute(): Result<Int> {
+        return try {
+            val currentTime = Clock.System.now()
+            val deletedCount = reminderRepository.deleteExpiredReminders(currentTime)
+            Result.success(deletedCount)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/state/ReminderListState.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/state/ReminderListState.kt
@@ -8,9 +8,11 @@ import com.maropiyo.reminderparrot.domain.entity.Reminder
  * @property reminders リマインダーのリスト
  * @property isLoading ローディング中かどうか
  * @property error エラーメッセージ
+ * @property lastUpdated 最終更新時刻（リアルタイム表示用）
  */
 data class ReminderListState(
     val reminders: List<Reminder> = listOf(),
     val isLoading: Boolean = false,
-    val error: String? = null
+    val error: String? = null,
+    val lastUpdated: Long = 0L
 )

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ReminderListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ReminderListViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
 
 /**
  * リマインダー一覧のビューモデル
@@ -209,7 +210,7 @@ class ReminderListViewModel(
                             loadReminders()
                         } else {
                             // 削除がない場合でも、時間表示の更新のためにStateを更新
-                            _state.update { it.copy(lastUpdated = System.currentTimeMillis()) }
+                            _state.update { it.copy(lastUpdated = Clock.System.now().toEpochMilliseconds()) }
                         }
                     }
             }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ReminderListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ReminderListViewModel.kt
@@ -4,10 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.maropiyo.reminderparrot.domain.usecase.AddParrotExperienceUseCase
 import com.maropiyo.reminderparrot.domain.usecase.CreateReminderUseCase
+import com.maropiyo.reminderparrot.domain.usecase.DeleteExpiredRemindersUseCase
 import com.maropiyo.reminderparrot.domain.usecase.DeleteReminderUseCase
 import com.maropiyo.reminderparrot.domain.usecase.GetRemindersUseCase
 import com.maropiyo.reminderparrot.domain.usecase.UpdateReminderUseCase
 import com.maropiyo.reminderparrot.presentation.state.ReminderListState
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -22,6 +24,7 @@ import kotlinx.coroutines.launch
  * @property createReminderUseCase リマインダー作成ユースケース
  * @property updateReminderUseCase リマインダー更新ユースケース
  * @property deleteReminderUseCase リマインダー削除ユースケース
+ * @property deleteExpiredRemindersUseCase 期限切れリマインダー削除ユースケース
  * @property addParrotExperienceUseCase インコの経験値追加ユースケース
  */
 class ReminderListViewModel(
@@ -29,14 +32,20 @@ class ReminderListViewModel(
     private val createReminderUseCase: CreateReminderUseCase,
     private val updateReminderUseCase: UpdateReminderUseCase,
     private val deleteReminderUseCase: DeleteReminderUseCase,
+    private val deleteExpiredRemindersUseCase: DeleteExpiredRemindersUseCase,
     private val addParrotExperienceUseCase: AddParrotExperienceUseCase
 ) : ViewModel() {
     private val _state = MutableStateFlow(ReminderListState())
     val state: StateFlow<ReminderListState> = _state.asStateFlow()
 
+    // 定期更新用のJob
+    private var periodicUpdateJob: Job? = null
+
     init {
         // 初期化時にリマインダーを取得
         loadReminders()
+        // 定期的な更新を開始
+        startPeriodicUpdate()
     }
 
     /**
@@ -171,6 +180,9 @@ class ReminderListViewModel(
         viewModelScope.launch {
             _state.update { it.copy(isLoading = true, error = null) }
 
+            // 期限切れリマインダーを削除
+            deleteExpiredRemindersUseCase.execute()
+
             getRemindersUseCase()
                 .onSuccess { reminders ->
                     _state.update { it.copy(reminders = reminders, isLoading = false) }
@@ -178,5 +190,37 @@ class ReminderListViewModel(
                     _state.update { it.copy(error = exception.message, isLoading = false) }
                 }
         }
+    }
+
+    /**
+     * 定期的な更新を開始する
+     * 1分ごとに期限切れリマインダーの削除とUIの更新を行う
+     */
+    private fun startPeriodicUpdate() {
+        periodicUpdateJob = viewModelScope.launch {
+            while (true) {
+                delay(60_000) // 1分待機
+
+                // 期限切れリマインダーを削除
+                deleteExpiredRemindersUseCase.execute()
+                    .onSuccess { deletedCount ->
+                        if (deletedCount > 0) {
+                            // 削除されたリマインダーがある場合はリストを更新
+                            loadReminders()
+                        } else {
+                            // 削除がない場合でも、時間表示の更新のためにStateを更新
+                            _state.update { it.copy(lastUpdated = System.currentTimeMillis()) }
+                        }
+                    }
+            }
+        }
+    }
+
+    /**
+     * ViewModel破棄時のクリーンアップ
+     */
+    override fun onCleared() {
+        super.onCleared()
+        periodicUpdateJob?.cancel()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/common/CountdownText.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/common/CountdownText.kt
@@ -1,0 +1,62 @@
+package com.maropiyo.reminderparrot.ui.components.common
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import com.maropiyo.reminderparrot.ui.util.TimeFormatUtil
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * カウントダウンテキスト
+ * リアルタイムで残り時間を更新表示するテキストコンポーネント
+ *
+ * @param forgetAt 忘却時刻
+ * @param textStyle テキストスタイル
+ * @param color テキストカラー
+ * @param modifier 修飾子
+ */
+@Composable
+fun CountdownText(forgetAt: Instant, textStyle: TextStyle, color: Color, modifier: Modifier = Modifier) {
+    // 現在の残り時間テキストを保持
+    var timeText by remember { mutableStateOf(TimeFormatUtil.formatTimeUntilForget(forgetAt)) }
+
+    // 1秒ごとに更新
+    LaunchedEffect(forgetAt) {
+        while (isActive) {
+            timeText = TimeFormatUtil.formatTimeUntilForget(forgetAt)
+
+            // 既に忘れた場合は更新を停止
+            if (forgetAt <= Clock.System.now()) {
+                break
+            }
+
+            // 1秒待機
+            delay(1000)
+        }
+    }
+
+    // コンポーネントが破棄される際のクリーンアップ
+    DisposableEffect(forgetAt) {
+        onDispose {
+            // LaunchedEffectは自動的にキャンセルされるため特別な処理は不要
+        }
+    }
+
+    Text(
+        text = timeText,
+        style = textStyle,
+        color = color,
+        modifier = modifier
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/common/CountdownText.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/common/CountdownText.kt
@@ -42,13 +42,13 @@ fun CountdownText(
     LaunchedEffect(forgetAt) {
         while (isActive) {
             val currentTime = Clock.System.now()
-            
+
             // 既に忘れた場合は削除を実行
             if (forgetAt <= currentTime) {
                 onExpired()
                 break
             }
-            
+
             timeText = TimeFormatUtil.formatTimeUntilForget(forgetAt, currentTime)
 
             // 1秒待機

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/common/CountdownText.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/common/CountdownText.kt
@@ -24,22 +24,32 @@ import kotlinx.datetime.Instant
  * @param forgetAt 忘却時刻
  * @param textStyle テキストスタイル
  * @param color テキストカラー
+ * @param onExpired 時間切れ時のコールバック
  * @param modifier 修飾子
  */
 @Composable
-fun CountdownText(forgetAt: Instant, textStyle: TextStyle, color: Color, modifier: Modifier = Modifier) {
+fun CountdownText(
+    forgetAt: Instant,
+    textStyle: TextStyle,
+    color: Color,
+    onExpired: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     // 現在の残り時間テキストを保持
     var timeText by remember { mutableStateOf(TimeFormatUtil.formatTimeUntilForget(forgetAt)) }
 
     // 1秒ごとに更新
     LaunchedEffect(forgetAt) {
         while (isActive) {
-            timeText = TimeFormatUtil.formatTimeUntilForget(forgetAt)
-
-            // 既に忘れた場合は更新を停止
-            if (forgetAt <= Clock.System.now()) {
+            val currentTime = Clock.System.now()
+            
+            // 既に忘れた場合は削除を実行
+            if (forgetAt <= currentTime) {
+                onExpired()
                 break
             }
+            
+            timeText = TimeFormatUtil.formatTimeUntilForget(forgetAt, currentTime)
 
             // 1秒待機
             delay(1000)

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
@@ -31,7 +31,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -123,6 +122,7 @@ fun ReminderContent(
                     editingReminder = reminder
                     isShowEditBottomSheet = true
                 },
+                onDeleteReminder = onDeleteReminder,
                 modifier = Modifier.weight(1f).fillMaxWidth()
             )
         }
@@ -222,6 +222,7 @@ private fun ReminderItems(
     state: ReminderListState,
     onToggleCompletion: (String) -> Unit,
     onReminderClick: (Reminder) -> Unit,
+    onDeleteReminder: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     when {
@@ -250,6 +251,9 @@ private fun ReminderItems(
                         reminder = reminder,
                         onToggleCompletion = { onToggleCompletion(reminder.id) },
                         onCardClick = { onReminderClick(reminder) },
+                        onDeleteReminder = { // 期限切れによる自動削除は直接実行
+                            onDeleteReminder(reminder.id)
+                        },
                         modifier = Modifier.padding(vertical = 8.dp)
                     )
                 }
@@ -267,6 +271,7 @@ private fun AnimatedReminderCard(
     reminder: Reminder,
     onToggleCompletion: () -> Unit,
     onCardClick: () -> Unit,
+    onDeleteReminder: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var isVisible by remember { mutableStateOf(true) }
@@ -293,7 +298,8 @@ private fun AnimatedReminderCard(
                     onToggleCompletion()
                 }
             },
-            onCardClick = onCardClick
+            onCardClick = onCardClick,
+            onDeleteReminder = onDeleteReminder
         )
     }
 }
@@ -307,6 +313,7 @@ private fun ReminderCard(
     reminder: Reminder,
     onToggleCompletion: () -> Unit,
     onCardClick: () -> Unit,
+    onDeleteReminder: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -356,7 +363,7 @@ private fun ReminderCard(
                 forgetAt = reminder.forgetAt,
                 textStyle = MaterialTheme.typography.bodySmall,
                 color = Secondary.copy(alpha = 0.7f),
-                onExpired = { onToggleCompletion() },
+                onExpired = { onDeleteReminder() },
                 modifier = Modifier.padding(top = 4.dp)
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
@@ -57,11 +57,8 @@ import com.maropiyo.reminderparrot.ui.theme.ParrotYellow
 import com.maropiyo.reminderparrot.ui.theme.Secondary
 import com.maropiyo.reminderparrot.ui.theme.Shapes
 import com.maropiyo.reminderparrot.ui.theme.White
-import com.maropiyo.reminderparrot.ui.util.TimeFormatUtil
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
 import org.jetbrains.compose.resources.painterResource
 import reminderparrot.composeapp.generated.resources.Res
 import reminderparrot.composeapp.generated.resources.reminko_face
@@ -312,30 +309,13 @@ private fun ReminderCard(
     onCardClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // 透過度をリアルタイムで更新
-    var alpha by remember { mutableStateOf(TimeFormatUtil.calculateAlpha(reminder.forgetAt, reminder.createdAt)) }
-
-    // 1秒ごとに透過度を更新
-    LaunchedEffect(reminder.forgetAt) {
-        while (isActive) {
-            alpha = TimeFormatUtil.calculateAlpha(reminder.forgetAt, reminder.createdAt)
-
-            // 既に忘れた場合は更新を停止
-            if (reminder.forgetAt <= Clock.System.now()) {
-                break
-            }
-
-            delay(1000)
-        }
-    }
-
     Card(
         modifier = modifier
             .fillMaxWidth()
             .clickable { onCardClick() },
         colors =
         CardDefaults.cardColors(
-            containerColor = White.copy(alpha = alpha)
+            containerColor = White
         ),
         shape = Shapes.extraLarge,
         elevation =

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
@@ -55,6 +55,7 @@ import com.maropiyo.reminderparrot.ui.theme.ParrotYellow
 import com.maropiyo.reminderparrot.ui.theme.Secondary
 import com.maropiyo.reminderparrot.ui.theme.Shapes
 import com.maropiyo.reminderparrot.ui.theme.White
+import com.maropiyo.reminderparrot.ui.util.TimeFormatUtil
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
@@ -307,13 +308,17 @@ private fun ReminderCard(
     onCardClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    // 残り時間と透過度を計算
+    val timeUntilForget = TimeFormatUtil.formatTimeUntilForget(reminder.forgetAt)
+    val alpha = TimeFormatUtil.calculateAlpha(reminder.forgetAt, reminder.createdAt)
+
     Card(
         modifier = modifier
             .fillMaxWidth()
             .clickable { onCardClick() },
         colors =
         CardDefaults.cardColors(
-            containerColor = White
+            containerColor = White.copy(alpha = alpha)
         ),
         shape = Shapes.extraLarge,
         elevation =
@@ -321,29 +326,40 @@ private fun ReminderCard(
             defaultElevation = 4.dp
         )
     ) {
-        Row(
-            modifier =
-            Modifier
+        Column(
+            modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+                .padding(16.dp)
         ) {
-            // テキスト
-            Text(
-                text = reminder.text,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color = Secondary,
-                textDecoration = if (reminder.isCompleted) TextDecoration.LineThrough else TextDecoration.None,
-                modifier = Modifier.weight(1f)
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // テキスト
+                Text(
+                    text = reminder.text,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = Secondary,
+                    textDecoration = if (reminder.isCompleted) TextDecoration.LineThrough else TextDecoration.None,
+                    modifier = Modifier.weight(1f)
+                )
 
-            // 丸いチェックボックス
-            CircularCheckbox(
-                checked = reminder.isCompleted,
-                onCheckedChange = { onToggleCompletion() },
-                modifier = Modifier.size(32.dp)
+                // 丸いチェックボックス
+                CircularCheckbox(
+                    checked = reminder.isCompleted,
+                    onCheckedChange = { onToggleCompletion() },
+                    modifier = Modifier.size(32.dp)
+                )
+            }
+
+            // 残り時間表示
+            Text(
+                text = timeUntilForget,
+                style = MaterialTheme.typography.bodySmall,
+                color = Secondary.copy(alpha = 0.7f),
+                modifier = Modifier.padding(top = 4.dp)
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
@@ -356,6 +356,7 @@ private fun ReminderCard(
                 forgetAt = reminder.forgetAt,
                 textStyle = MaterialTheme.typography.bodySmall,
                 color = Secondary.copy(alpha = 0.7f),
+                onExpired = { onToggleCompletion() },
                 modifier = Modifier.padding(top = 4.dp)
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
@@ -1,0 +1,63 @@
+package com.maropiyo.reminderparrot.ui.util
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * 時間フォーマットユーティリティ
+ */
+object TimeFormatUtil {
+    /**
+     * 忘却までの残り時間を子供にも分かりやすいフォーマットで返す
+     *
+     * @param forgetAt 忘却時刻
+     * @param currentTime 現在時刻
+     * @return フォーマットされた時間文字列
+     */
+    fun formatTimeUntilForget(forgetAt: Instant, currentTime: Instant = Clock.System.now()): String {
+        val remainingDuration = forgetAt - currentTime
+
+        return when {
+            remainingDuration <= Duration.ZERO -> "もうわすれちゃった"
+            remainingDuration >= 1.days -> {
+                val days = remainingDuration.inWholeDays
+                "わすれるまであと${days}にち"
+            }
+            remainingDuration >= 1.hours -> {
+                val hours = remainingDuration.inWholeHours
+                "わすれるまであと${hours}じかん"
+            }
+            else -> {
+                val minutes = remainingDuration.inWholeMinutes
+                val displayMinutes = maxOf(1, minutes) // 最低1分と表示
+                "わすれるまであと${displayMinutes}ふん"
+            }
+        }
+    }
+
+    /**
+     * 残り時間に基づく透過度を計算する
+     * * @param forgetAt 忘却時刻
+     * @param createdAt 作成時刻
+     * @param currentTime 現在時刻
+     * @return 透過度（0.2〜1.0）
+     */
+    fun calculateAlpha(forgetAt: Instant, createdAt: Instant, currentTime: Instant = Clock.System.now()): Float {
+        val totalDuration = forgetAt - createdAt
+        val remainingDuration = forgetAt - currentTime
+
+        return when {
+            remainingDuration <= Duration.ZERO -> 0.2f
+            remainingDuration >= totalDuration -> 1.0f
+            else -> {
+                val progress = remainingDuration.inWholeMilliseconds.toFloat() /
+                    totalDuration.inWholeMilliseconds.toFloat()
+                0.2f + (0.8f * progress) // 0.2から1.0の範囲で透過度を計算
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
@@ -28,26 +28,26 @@ object TimeFormatUtil {
                 val days = remainingDuration.inWholeDays
                 val hours = (remainingDuration - days.days).inWholeHours
                 if (hours > 0) {
-                    "わすれるまであと${days}にちと${hours}じかん"
+                    "わすれるまであと${days}日と${hours}時間"
                 } else {
-                    "わすれるまであと${days}にち"
+                    "わすれるまであと${days}日"
                 }
             }
             remainingDuration >= 1.hours -> {
                 val hours = remainingDuration.inWholeHours
                 val minutes = (remainingDuration - hours.hours).inWholeMinutes
                 val seconds = (remainingDuration - hours.hours - minutes.minutes).inWholeSeconds
-                "わすれるまであと${hours}じかん${minutes}ふん${seconds}びょう"
+                "わすれるまであと${hours}時間${minutes}分${seconds}秒"
             }
             remainingDuration >= 1.minutes -> {
                 val minutes = remainingDuration.inWholeMinutes
                 val seconds = (remainingDuration - minutes.minutes).inWholeSeconds
-                "わすれるまであと${minutes}ふん${seconds}びょう"
+                "わすれるまであと${minutes}分${seconds}秒"
             }
             else -> {
                 val seconds = remainingDuration.inWholeSeconds
                 val displaySeconds = maxOf(1, seconds) // 最低1秒と表示
-                "わすれるまであと${displaySeconds}びょう"
+                "わすれるまであと${displaySeconds}秒"
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
@@ -1,10 +1,10 @@
 package com.maropiyo.reminderparrot.ui.util
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 
 /**
  * 時間フォーマットユーティリティ
@@ -17,10 +17,7 @@ object TimeFormatUtil {
      * @param currentTime 現在時刻
      * @return フォーマットされた時間文字列
      */
-    fun formatTimeUntilForget(
-        forgetAt: Instant,
-        currentTime: Instant = Clock.System.now()
-    ): String {
+    fun formatTimeUntilForget(forgetAt: Instant, currentTime: Instant = Clock.System.now()): String {
         val remainingDuration = forgetAt - currentTime
 
         return when {

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
@@ -45,7 +45,11 @@ object TimeFormatUtil {
             }
             else -> {
                 val seconds = remainingDuration.inWholeSeconds
-                "わすれるまであと${seconds}秒"
+                if (seconds <= 0) {
+                    "ぽかん！"
+                } else {
+                    "わすれるまであと${seconds}秒"
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
@@ -4,6 +4,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
@@ -25,16 +26,28 @@ object TimeFormatUtil {
             remainingDuration <= Duration.ZERO -> "もうわすれちゃった"
             remainingDuration >= 1.days -> {
                 val days = remainingDuration.inWholeDays
-                "わすれるまであと${days}にち"
+                val hours = (remainingDuration - days.days).inWholeHours
+                if (hours > 0) {
+                    "わすれるまであと${days}にちと${hours}じかん"
+                } else {
+                    "わすれるまであと${days}にち"
+                }
             }
             remainingDuration >= 1.hours -> {
                 val hours = remainingDuration.inWholeHours
-                "わすれるまであと${hours}じかん"
+                val minutes = (remainingDuration - hours.hours).inWholeMinutes
+                val seconds = (remainingDuration - hours.hours - minutes.minutes).inWholeSeconds
+                "わすれるまであと${hours}じかん${minutes}ふん${seconds}びょう"
+            }
+            remainingDuration >= 1.minutes -> {
+                val minutes = remainingDuration.inWholeMinutes
+                val seconds = (remainingDuration - minutes.minutes).inWholeSeconds
+                "わすれるまであと${minutes}ふん${seconds}びょう"
             }
             else -> {
-                val minutes = remainingDuration.inWholeMinutes
-                val displayMinutes = maxOf(1, minutes) // 最低1分と表示
-                "わすれるまであと${displayMinutes}ふん"
+                val seconds = remainingDuration.inWholeSeconds
+                val displaySeconds = maxOf(1, seconds) // 最低1秒と表示
+                "わすれるまであと${displaySeconds}びょう"
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
@@ -1,29 +1,29 @@
 package com.maropiyo.reminderparrot.ui.util
 
-import kotlin.time.Duration
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 
 /**
  * 時間フォーマットユーティリティ
  */
 object TimeFormatUtil {
     /**
-     * 忘却までの残り時間を子供にも分かりやすいフォーマットで返す
+     * 忘却までの残り時間を返す
      *
      * @param forgetAt 忘却時刻
      * @param currentTime 現在時刻
      * @return フォーマットされた時間文字列
      */
-    fun formatTimeUntilForget(forgetAt: Instant, currentTime: Instant = Clock.System.now()): String {
+    fun formatTimeUntilForget(
+        forgetAt: Instant,
+        currentTime: Instant = Clock.System.now()
+    ): String {
         val remainingDuration = forgetAt - currentTime
 
         return when {
-            remainingDuration <= Duration.ZERO -> "もうわすれちゃった"
             remainingDuration >= 1.days -> {
                 val days = remainingDuration.inWholeDays
                 val hours = (remainingDuration - days.days).inWholeHours
@@ -45,30 +45,7 @@ object TimeFormatUtil {
             }
             else -> {
                 val seconds = remainingDuration.inWholeSeconds
-                val displaySeconds = maxOf(1, seconds) // 最低1秒と表示
-                "わすれるまであと${displaySeconds}秒"
-            }
-        }
-    }
-
-    /**
-     * 残り時間に基づく透過度を計算する
-     * * @param forgetAt 忘却時刻
-     * @param createdAt 作成時刻
-     * @param currentTime 現在時刻
-     * @return 透過度（0.2〜1.0）
-     */
-    fun calculateAlpha(forgetAt: Instant, createdAt: Instant, currentTime: Instant = Clock.System.now()): Float {
-        val totalDuration = forgetAt - createdAt
-        val remainingDuration = forgetAt - currentTime
-
-        return when {
-            remainingDuration <= Duration.ZERO -> 0.2f
-            remainingDuration >= totalDuration -> 1.0f
-            else -> {
-                val progress = remainingDuration.inWholeMilliseconds.toFloat() /
-                    totalDuration.inWholeMilliseconds.toFloat()
-                0.2f + (0.8f * progress) // 0.2から1.0の範囲で透過度を計算
+                "わすれるまであと${seconds}秒"
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/util/TimeFormatUtil.kt
@@ -36,8 +36,7 @@ object TimeFormatUtil {
             remainingDuration >= 1.hours -> {
                 val hours = remainingDuration.inWholeHours
                 val minutes = (remainingDuration - hours.hours).inWholeMinutes
-                val seconds = (remainingDuration - hours.hours - minutes.minutes).inWholeSeconds
-                "わすれるまであと${hours}時間${minutes}分${seconds}秒"
+                "わすれるまであと${hours}時間${minutes}分"
             }
             remainingDuration >= 1.minutes -> {
                 val minutes = remainingDuration.inWholeMinutes

--- a/composeApp/src/commonMain/sqldelight/com/maropiyo/reminderparrot/db/ReminderParrotDatabase.sq
+++ b/composeApp/src/commonMain/sqldelight/com/maropiyo/reminderparrot/db/ReminderParrotDatabase.sq
@@ -1,12 +1,14 @@
 CREATE TABLE Reminder (
     id TEXT PRIMARY KEY,
     text TEXT NOT NULL,
-    is_completed INTEGER NOT NULL DEFAULT 0
+    is_completed INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    forget_at INTEGER NOT NULL
 );
 
 insertReminder:
-INSERT INTO Reminder(id, text, is_completed)
-VALUES(?, ?, ?);
+INSERT INTO Reminder(id, text, is_completed, created_at, forget_at)
+VALUES(?, ?, ?, ?, ?);
 
 selectAllReminders:
 SELECT Reminder.*
@@ -23,6 +25,10 @@ WHERE id = ?;
 
 removeAllReminders:
 DELETE FROM Reminder;
+
+deleteExpiredReminders:
+DELETE FROM Reminder
+WHERE forget_at < ?;
 
 -- Parrotテーブルの定義
 CREATE TABLE Parrot (

--- a/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/data/repository/ReminderRepositoryImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/data/repository/ReminderRepositoryImplTest.kt
@@ -4,7 +4,9 @@ import com.maropiyo.reminderparrot.domain.entity.Reminder
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
 
 /**
  * ReminderRepositoryImplのテストクラス
@@ -115,7 +117,13 @@ class ReminderRepositoryImplTest {
     @Test
     fun `createReminder - 正常な場合はリマインダーが作成される`() = runTest {
         // Given
-        val reminder = Reminder(id = "1", text = "テストリマインダー")
+        val currentTime = Clock.System.now()
+        val reminder = Reminder(
+            id = "1",
+            text = "テストリマインダー",
+            createdAt = currentTime,
+            forgetAt = currentTime + 24.hours
+        )
         testLocalDataSource.reset()
         testLocalDataSource.setReminderToReturn(reminder)
 
@@ -133,7 +141,13 @@ class ReminderRepositoryImplTest {
     @Test
     fun `createReminder - ローカルデータソースエラーの場合はFailureが返される`() = runTest {
         // Given
-        val reminder = Reminder(id = "1", text = "エラーテスト")
+        val currentTime = Clock.System.now()
+        val reminder = Reminder(
+            id = "1",
+            text = "エラーテスト",
+            createdAt = currentTime,
+            forgetAt = currentTime + 24.hours
+        )
         val exception = RuntimeException("ローカル保存エラー")
         testLocalDataSource.reset()
         testLocalDataSource.setShouldThrowException(exception)
@@ -152,9 +166,21 @@ class ReminderRepositoryImplTest {
     @Test
     fun `getReminders - 正常な場合はリマインダーリストが返される`() = runTest {
         // Given
+        val currentTime = Clock.System.now()
         val reminders = listOf(
-            Reminder(id = "1", text = "テスト1"),
-            Reminder(id = "2", text = "テスト2", isCompleted = true)
+            Reminder(
+                id = "1",
+                text = "テスト1",
+                createdAt = currentTime,
+                forgetAt = currentTime + 24.hours
+            ),
+            Reminder(
+                id = "2",
+                text = "テスト2",
+                isCompleted = true,
+                createdAt = currentTime,
+                forgetAt = currentTime + 24.hours
+            )
         )
         testLocalDataSource.reset()
         testLocalDataSource.setRemindersToReturn(reminders)
@@ -191,7 +217,14 @@ class ReminderRepositoryImplTest {
     @Test
     fun `updateReminder - 正常な場合はUnitが返される`() = runTest {
         // Given
-        val reminder = Reminder(id = "1", text = "更新テスト", isCompleted = true)
+        val currentTime = Clock.System.now()
+        val reminder = Reminder(
+            id = "1",
+            text = "更新テスト",
+            isCompleted = true,
+            createdAt = currentTime,
+            forgetAt = currentTime + 24.hours
+        )
         testLocalDataSource.reset()
 
         // When
@@ -208,7 +241,13 @@ class ReminderRepositoryImplTest {
     @Test
     fun `updateReminder - ローカルデータソースエラーの場合はFailureが返される`() = runTest {
         // Given
-        val reminder = Reminder(id = "1", text = "エラーテスト")
+        val currentTime = Clock.System.now()
+        val reminder = Reminder(
+            id = "1",
+            text = "エラーテスト",
+            createdAt = currentTime,
+            forgetAt = currentTime + 24.hours
+        )
         val exception = RuntimeException("更新エラー")
         testLocalDataSource.reset()
         testLocalDataSource.setShouldThrowException(exception)

--- a/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCaseTest.kt
@@ -6,7 +6,10 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 
 /**
  * CreateReminderUseCaseのテストクラス
@@ -58,6 +61,10 @@ class CreateReminderUseCaseTest {
         override suspend fun deleteReminder(reminderId: String): Result<Unit> {
             return Result.success(Unit)
         }
+
+        override suspend fun deleteExpiredReminders(currentTime: Instant): Int {
+            return 0
+        }
     }
 
     /**
@@ -84,7 +91,13 @@ class CreateReminderUseCaseTest {
     ) {
         suspend operator fun invoke(text: String): Result<Reminder> {
             val id = uuidGenerator.generateId()
-            val reminder = Reminder(id = id, text = text)
+            val currentTime = Clock.System.now()
+            val reminder = Reminder(
+                id = id,
+                text = text,
+                createdAt = currentTime,
+                forgetAt = currentTime + 24.hours
+            )
             return repository.createReminder(reminder)
         }
     }
@@ -101,7 +114,13 @@ class CreateReminderUseCaseTest {
         // Given
         val testText = "新しいリマインダー"
         val testId = "test-uuid-123"
-        val expectedReminder = Reminder(id = testId, text = testText)
+        val currentTime = Clock.System.now()
+        val expectedReminder = Reminder(
+            id = testId,
+            text = testText,
+            createdAt = currentTime,
+            forgetAt = currentTime + 24.hours
+        )
 
         testRepository.reset()
         testUuidGenerator.setIdToReturn(testId)
@@ -148,7 +167,13 @@ class CreateReminderUseCaseTest {
         // Given
         val testText = ""
         val testId = "test-uuid-789"
-        val expectedReminder = Reminder(id = testId, text = testText)
+        val currentTime = Clock.System.now()
+        val expectedReminder = Reminder(
+            id = testId,
+            text = testText,
+            createdAt = currentTime,
+            forgetAt = currentTime + 24.hours
+        )
 
         testRepository.reset()
         testUuidGenerator.setIdToReturn(testId)

--- a/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/GetRemindersUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/GetRemindersUseCaseTest.kt
@@ -5,7 +5,10 @@ import com.maropiyo.reminderparrot.domain.repository.ReminderRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 
 /**
  * GetRemindersUseCaseのテストクラス
@@ -57,6 +60,10 @@ class GetRemindersUseCaseTest {
         override suspend fun deleteReminder(reminderId: String): Result<Unit> {
             return Result.success(Unit)
         }
+
+        override suspend fun deleteExpiredReminders(currentTime: Instant): Int {
+            return 0
+        }
     }
 
     /**
@@ -79,9 +86,21 @@ class GetRemindersUseCaseTest {
     @Test
     fun `正常な場合はリマインダーリストが返される`() = runTest {
         // Given
+        val currentTime = Clock.System.now()
         val expectedReminders = listOf(
-            Reminder(id = "1", text = "テスト1"),
-            Reminder(id = "2", text = "テスト2", isCompleted = true)
+            Reminder(
+                id = "1",
+                text = "テスト1",
+                createdAt = currentTime,
+                forgetAt = currentTime + 24.hours
+            ),
+            Reminder(
+                id = "2",
+                text = "テスト2",
+                isCompleted = true,
+                createdAt = currentTime,
+                forgetAt = currentTime + 24.hours
+            )
         )
         testRepository.reset()
         testRepository.setRemindersToReturn(expectedReminders)

--- a/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/UpdateReminderUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/UpdateReminderUseCaseTest.kt
@@ -5,7 +5,10 @@ import com.maropiyo.reminderparrot.domain.repository.ReminderRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 
 /**
  * UpdateReminderUseCaseのテストクラス
@@ -55,6 +58,10 @@ class UpdateReminderUseCaseTest {
         override suspend fun deleteReminder(reminderId: String): Result<Unit> {
             return Result.success(Unit)
         }
+
+        override suspend fun deleteExpiredReminders(currentTime: Instant): Int {
+            return 0
+        }
     }
 
     /**
@@ -77,7 +84,14 @@ class UpdateReminderUseCaseTest {
     @Test
     fun `正常な場合はリマインダーが更新される`() = runTest {
         // Given
-        val reminder = Reminder(id = "1", text = "更新テスト", isCompleted = true)
+        val currentTime = Clock.System.now()
+        val reminder = Reminder(
+            id = "1",
+            text = "更新テスト",
+            isCompleted = true,
+            createdAt = currentTime,
+            forgetAt = currentTime + 24.hours
+        )
         testRepository.reset()
         testRepository.setShouldReturnSuccess()
 
@@ -94,7 +108,13 @@ class UpdateReminderUseCaseTest {
     @Test
     fun `リポジトリエラーの場合はFailureが返される`() = runTest {
         // Given
-        val reminder = Reminder(id = "1", text = "エラーテスト")
+        val currentTime = Clock.System.now()
+        val reminder = Reminder(
+            id = "1",
+            text = "エラーテスト",
+            createdAt = currentTime,
+            forgetAt = currentTime + 24.hours
+        )
         val exception = RuntimeException("更新エラー")
         testRepository.reset()
         testRepository.setShouldReturnFailure(exception)
@@ -113,7 +133,14 @@ class UpdateReminderUseCaseTest {
     @Test
     fun `完了状態のリマインダーも正常に更新される`() = runTest {
         // Given
-        val completedReminder = Reminder(id = "2", text = "完了済み", isCompleted = true)
+        val currentTime = Clock.System.now()
+        val completedReminder = Reminder(
+            id = "2",
+            text = "完了済み",
+            isCompleted = true,
+            createdAt = currentTime,
+            forgetAt = currentTime + 24.hours
+        )
         testRepository.reset()
         testRepository.setShouldReturnSuccess()
 

--- a/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ReminderListViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ReminderListViewModelTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -19,6 +20,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.datetime.Clock
 
 /**
  * ReminderListViewModelのテストクラス
@@ -89,7 +91,15 @@ class ReminderListViewModelTest {
             return if (shouldReturnFailure) {
                 Result.failure(exceptionToThrow!!)
             } else {
-                Result.success(reminderToReturn ?: Reminder(id = "test-id", text = text))
+                val currentTime = Clock.System.now()
+                Result.success(
+                    reminderToReturn ?: Reminder(
+                        id = "test-id",
+                        text = text,
+                        createdAt = currentTime,
+                        forgetAt = currentTime + 24.hours
+                    )
+                )
             }
         }
     }
@@ -230,9 +240,21 @@ class ReminderListViewModelTest {
     @Test
     fun `初期状態は正しく設定される`() = runTest {
         // Given
+        val currentTime = Clock.System.now()
         val reminders = listOf(
-            Reminder(id = "1", text = "テスト1"),
-            Reminder(id = "2", text = "テスト2", isCompleted = true)
+            Reminder(
+                id = "1",
+                text = "テスト1",
+                createdAt = currentTime,
+                forgetAt = currentTime + 24.hours
+            ),
+            Reminder(
+                id = "2",
+                text = "テスト2",
+                isCompleted = true,
+                createdAt = currentTime,
+                forgetAt = currentTime + 24.hours
+            )
         )
         testGetRemindersUseCase.setRemindersToReturn(reminders)
 
@@ -260,8 +282,21 @@ class ReminderListViewModelTest {
     @Test
     fun `createReminder - 正常な場合はリマインダーが追加される`() = runTest {
         // Given
-        val initialReminders = listOf(Reminder(id = "1", text = "既存"))
-        val newReminder = Reminder(id = "2", text = "新規")
+        val currentTime = Clock.System.now()
+        val initialReminders = listOf(
+            Reminder(
+                id = "1",
+                text = "既存",
+                createdAt = currentTime,
+                forgetAt = currentTime + 24.hours
+            )
+        )
+        val newReminder = Reminder(
+            id = "2",
+            text = "新規",
+            createdAt = currentTime,
+            forgetAt = currentTime + 24.hours
+        )
 
         testGetRemindersUseCase.setRemindersToReturn(initialReminders)
         testCreateReminderUseCase.setReminderToReturn(newReminder)
@@ -291,7 +326,15 @@ class ReminderListViewModelTest {
     @Test
     fun `createReminder - エラーの場合はエラーメッセージが設定される`() = runTest {
         // Given
-        val initialReminders = listOf(Reminder(id = "1", text = "既存"))
+        val currentTime = Clock.System.now()
+        val initialReminders = listOf(
+            Reminder(
+                id = "1",
+                text = "既存",
+                createdAt = currentTime,
+                forgetAt = currentTime + 24.hours
+            )
+        )
         val exception = RuntimeException("作成エラー")
 
         testGetRemindersUseCase.setRemindersToReturn(initialReminders)
@@ -320,7 +363,14 @@ class ReminderListViewModelTest {
     @Test
     fun `toggleReminderCompletion - 正常な場合は完了状態が切り替わる`() = runTest {
         // Given
-        val reminder = Reminder(id = "1", text = "テスト", isCompleted = false)
+        val currentTime = Clock.System.now()
+        val reminder = Reminder(
+            id = "1",
+            text = "テスト",
+            isCompleted = false,
+            createdAt = currentTime,
+            forgetAt = currentTime + 24.hours
+        )
 
         testGetRemindersUseCase.setRemindersToReturn(listOf(reminder))
         testUpdateReminderUseCase.setShouldReturnSuccess()
@@ -348,7 +398,14 @@ class ReminderListViewModelTest {
     @Test
     fun `toggleReminderCompletion - エラーの場合はエラーメッセージが設定される`() = runTest {
         // Given
-        val reminder = Reminder(id = "1", text = "テスト", isCompleted = false)
+        val currentTime = Clock.System.now()
+        val reminder = Reminder(
+            id = "1",
+            text = "テスト",
+            isCompleted = false,
+            createdAt = currentTime,
+            forgetAt = currentTime + 24.hours
+        )
         val exception = RuntimeException("更新エラー")
 
         testGetRemindersUseCase.setRemindersToReturn(listOf(reminder))
@@ -376,7 +433,13 @@ class ReminderListViewModelTest {
     @Test
     fun `toggleReminderCompletion - 存在しないIDの場合は何も起こらない`() = runTest {
         // Given
-        val reminder = Reminder(id = "1", text = "テスト")
+        val currentTime = Clock.System.now()
+        val reminder = Reminder(
+            id = "1",
+            text = "テスト",
+            createdAt = currentTime,
+            forgetAt = currentTime + 24.hours
+        )
         testGetRemindersUseCase.setRemindersToReturn(listOf(reminder))
 
         val viewModel = TestReminderListViewModel(
@@ -426,11 +489,36 @@ class ReminderListViewModelTest {
     @Test
     fun `リマインダーリストは未完了が先頭にソートされる`() = runTest {
         // Given
+        val currentTime = Clock.System.now()
         val reminders = listOf(
-            Reminder(id = "1", text = "完了済み", isCompleted = true),
-            Reminder(id = "2", text = "未完了1", isCompleted = false),
-            Reminder(id = "3", text = "未完了2", isCompleted = false),
-            Reminder(id = "4", text = "完了済み2", isCompleted = true)
+            Reminder(
+                id = "1",
+                text = "完了済み",
+                isCompleted = true,
+                createdAt = currentTime,
+                forgetAt = currentTime + 24.hours
+            ),
+            Reminder(
+                id = "2",
+                text = "未完了1",
+                isCompleted = false,
+                createdAt = currentTime,
+                forgetAt = currentTime + 24.hours
+            ),
+            Reminder(
+                id = "3",
+                text = "未完了2",
+                isCompleted = false,
+                createdAt = currentTime,
+                forgetAt = currentTime + 24.hours
+            ),
+            Reminder(
+                id = "4",
+                text = "完了済み2",
+                isCompleted = true,
+                createdAt = currentTime,
+                forgetAt = currentTime + 24.hours
+            )
         )
         testGetRemindersUseCase.setRemindersToReturn(reminders)
 


### PR DESCRIPTION
## Summary
- Reminderエンティティの変更（createdAt、forgetAtの必須化）に伴うテストファイルの修正
- TestReminderRepositoryにdeleteExpiredRemindersメソッドの実装を追加
- 必要なインポート（Clock、Instant、Duration）の追加

## Test plan
- [x] `./gradlew :composeApp:cleanAllTests :composeApp:allTests` で全テストが成功することを確認
- [x] `./gradlew ktlintFormat` でコードフォーマットを適用

## Changes
- 全てのReminderインスタンス作成時にcreatedAtとforgetAtパラメータを追加
- TestReminderRepositoryクラスにdeleteExpiredRemindersメソッドのダミー実装を追加
- ktlintによるimport順序とフォーマットの調整

🤖 Generated with [Claude Code](https://claude.ai/code)