### PR TITLE
feat(ios): アプリ表示名を「リマインコ」に設定

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -14,6 +14,8 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleDisplayName</key>
+	<string>リマインコ</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## 概要
iOSアプリの表示名を「リマインコ」に設定しました。

## 変更内容
- Info.plistに`CFBundleDisplayName`キーを追加
- 値を「リマインコ」に設定

## 影響範囲
- ホーム画面でのアプリ表示名が「リマインコ」になります
- App Storeでの表示名も「リマインコ」になります
- 内部的なアプリ名（`PRODUCT_NAME`）は変更していないため、`ReminderParrot.app`というファイル名は維持されます

## テスト方法
1. Xcodeでプロジェクトをビルド
2. シミュレータまたは実機にインストール
3. ホーム画面でアプリ名が「リマインコ」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)