### PR TITLE
feat(settings): 設定画面とリマインネット機能のUX改善

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,9 @@
       "mcp__supabase__list_edge_functions",
       "mcp__supabase__deploy_edge_function",
       "mcp__supabase__execute_sql",
-      "mcp__supabase__get_logs"
+      "mcp__supabase__get_logs",
+      "Bash(./gradlew:*)",
+      "Bash(git add:*)"
     ],
     "deny": []
   }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/service/AuthServiceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/service/AuthServiceImpl.kt
@@ -77,10 +77,20 @@ class AuthServiceImpl(
         val currentUser = supabaseClient.auth.currentUserOrNull()
             ?: throw IllegalStateException("ユーザーが認証されていません")
 
-        supabaseClient.auth.updateUser {
-            data = buildJsonObject {
-                put("display_name", displayName)
+        try {
+            println("AuthServiceImpl: 名前変更開始 - '$displayName' (ユーザーID: ${currentUser.id})")
+            
+            supabaseClient.auth.updateUser {
+                data = buildJsonObject {
+                    put("display_name", displayName)
+                }
             }
+            
+            println("AuthServiceImpl: 名前変更成功 - '$displayName'")
+        } catch (e: Exception) {
+            println("AuthServiceImpl: 名前変更エラー - ${e.message}")
+            println("AuthServiceImpl: エラー詳細 - $e")
+            throw e
         }
     }
 


### PR DESCRIPTION
## Summary
設定画面とリマインネット機能のユーザーエクスペリエンスを大幅に改善しました。

### 主な変更内容

#### 🔐 アカウント管理の改善
- 設定タブでの自動アカウント作成を防止
- リマインネット機能の有効化をリマインネットタブの「つかってみる」ボタンからのみ可能に変更
- アカウント未作成時は設定画面のインコ情報とリマインネット設定を非表示

#### 🎯 名前変更機能の改善
- 2重サブミット防止機能を実装
- 更新中のローディング状態表示（CircularProgressIndicator）
- ボタンの適切な有効/無効状態管理

#### 🚦 レートリミット対応
- Supabaseの`over_request_rate_limit`エラーの適切なハンドリング
- ユーザーフレンドリーなエラーメッセージの表示
- クライアント側での5秒クールダウン制限
- 非活性状態の視覚的フィードバック（「おしえる」ボタンと同じ38%透明度）

### 技術的な改善
- エラーログの詳細化でデバッグ性向上
- StateFlowによる適切な状態管理
- Snackbarによるエラー通知
- try-finally文でのリソース管理

## Test plan
- [ ] 設定タブに遷移してもアカウントが自動作成されないことを確認
- [ ] リマインネットタブの「つかってみる」ボタンからアカウント作成できることを確認
- [ ] アカウント未作成時に設定画面がシンプルに表示されることを確認
- [ ] 名前変更ボタンの連続クリックが適切に制御されることを確認
- [ ] 名前変更のレートリミットエラーが適切に表示されることを確認
- [ ] クールダウン期間中にボタンが非活性になることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)