### PR TITLE
feat(ui): リマインネット画面にスクロール・トゥ・トップ機能を追加

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Notifications
@@ -81,6 +82,9 @@ fun RemindNetScreen(remindNetViewModel: RemindNetViewModel = koinInject()) {
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
+    // リスト表示用のスクロール状態
+    val listState = rememberLazyListState()
+
     // プッシュ通知トークン登録
     val registerPushNotificationToken = koinInject<RegisterPushNotificationTokenUseCase>()
 
@@ -94,6 +98,13 @@ fun RemindNetScreen(remindNetViewModel: RemindNetViewModel = koinInject()) {
     // 画面に遷移した時に投稿を再取得
     LaunchedEffect(Unit) {
         remindNetViewModel.onScreenEntered()
+    }
+
+    // 投稿リストが更新された時に一番上にスクロール
+    LaunchedEffect(state.posts) {
+        if (state.posts.isNotEmpty()) {
+            listState.animateScrollToItem(0)
+        }
     }
 
     // エラー表示
@@ -190,6 +201,7 @@ fun RemindNetScreen(remindNetViewModel: RemindNetViewModel = koinInject()) {
             } else {
                 // 投稿リスト
                 LazyColumn(
+                    state = listState,
                     modifier =
                     Modifier
                         .fillMaxSize()

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -100,8 +100,8 @@ fun RemindNetScreen(remindNetViewModel: RemindNetViewModel = koinInject()) {
         remindNetViewModel.onScreenEntered()
     }
 
-    // 投稿リストが更新された時に一番上にスクロール
-    LaunchedEffect(state.posts) {
+    // 投稿リストに新しい投稿が追加された時に一番上にスクロール
+    LaunchedEffect(state.posts.size) {
         if (state.posts.isNotEmpty()) {
             listState.animateScrollToItem(0)
         }


### PR DESCRIPTION
## Summary

- リマインネット画面にスクロール・トゥ・トップ機能を実装
- LazyListStateを使用してリストのスクロール状態を管理
- 投稿リストが更新された時に自動的に画面上部にアニメーションスクロール

## Test plan

- [x] ktlint チェック完了
- [x] 全テスト実行完了
- [x] Android/iOS 両プラットフォームでのビルド確認

🤖 Generated with [Claude Code](https://claude.ai/code)