### PR TITLE
feat(remindnet): リマインネット投稿の削除機能を追加

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/datasource/remote/RemindNetRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/datasource/remote/RemindNetRemoteDataSource.kt
@@ -99,6 +99,24 @@ class RemindNetRemoteDataSource(
     }
 
     /**
+     * 投稿を削除する（物理削除）
+     */
+    suspend fun deletePost(postId: String, userId: String): Result<Unit> = try {
+        supabaseClient
+            .from("remind_net_posts")
+            .delete {
+                filter {
+                    eq("id", postId)
+                    eq("user_id", userId)
+                }
+            }
+
+        Result.success(Unit)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    /**
      * リマインド通知を送信する
      */
     suspend fun sendRemindNotification(notification: RemindNetNotification): Result<Unit> = try {

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/datasource/remote/RemindNetRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/datasource/remote/RemindNetRemoteDataSource.kt
@@ -102,13 +102,15 @@ class RemindNetRemoteDataSource(
      * 投稿を削除する（物理削除）
      */
     suspend fun deletePost(postId: String, userId: String): Result<Unit> = try {
-        supabaseClient
+        // selectを追加してSupabaseが削除操作を実際に実行するように強制
+        val result = supabaseClient
             .from("remind_net_posts")
             .delete {
                 filter {
                     eq("id", postId)
                     eq("user_id", userId)
                 }
+                select()
             }
 
         Result.success(Unit)

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/repository/RemindNetRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/repository/RemindNetRepositoryImpl.kt
@@ -33,6 +33,10 @@ class RemindNetRepositoryImpl(
         return remoteDataSource.likePost(postId)
     }
 
+    override suspend fun deletePost(postId: String, userId: String): Result<Unit> {
+        return remoteDataSource.deletePost(postId, userId)
+    }
+
     override suspend fun sendRemindNotification(notification: RemindNetNotification): Result<Unit> {
         return remoteDataSource.sendRemindNotification(notification)
     }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
@@ -30,6 +30,7 @@ import com.maropiyo.reminderparrot.domain.usecase.SendRemindNotificationUseCase
 import com.maropiyo.reminderparrot.domain.usecase.SignInAnonymouslyUseCase
 import com.maropiyo.reminderparrot.domain.usecase.UpdateReminderUseCase
 import com.maropiyo.reminderparrot.domain.usecase.remindnet.CreateRemindNetPostUseCase
+import com.maropiyo.reminderparrot.domain.usecase.remindnet.DeleteRemindNetPostUseCase
 import com.maropiyo.reminderparrot.domain.usecase.remindnet.GetRemindNetPostsUseCase
 import com.maropiyo.reminderparrot.presentation.viewmodel.ParrotViewModel
 import com.maropiyo.reminderparrot.presentation.viewmodel.RemindNetViewModel
@@ -47,7 +48,7 @@ val appModule =
             ReminderListViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get())
         }
         single<ParrotViewModel> { ParrotViewModel(get()) }
-        single<RemindNetViewModel> { RemindNetViewModel(get(), get(), get(), get()) }
+        single<RemindNetViewModel> { RemindNetViewModel(get(), get(), get(), get(), get()) }
         single<SettingsViewModel> { SettingsViewModel(get(), get(), get()) }
 
         // UseCase
@@ -62,6 +63,7 @@ val appModule =
         single<CancelForgetNotificationUseCase> { CancelForgetNotificationUseCase(get()) }
         single<RequestNotificationPermissionUseCase> { RequestNotificationPermissionUseCase(get()) }
         single<CreateRemindNetPostUseCase> { CreateRemindNetPostUseCase(get(), get()) }
+        single<DeleteRemindNetPostUseCase> { DeleteRemindNetPostUseCase(get()) }
         single<GetRemindNetPostsUseCase> { GetRemindNetPostsUseCase(get()) }
         single<SendRemindNotificationUseCase> { SendRemindNotificationUseCase(get(), get(), get()) }
         single<RegisterPushNotificationTokenUseCase> {

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/repository/RemindNetRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/repository/RemindNetRepository.kt
@@ -31,6 +31,11 @@ interface RemindNetRepository {
     suspend fun likePost(postId: String): Result<Unit>
 
     /**
+     * 投稿を削除する
+     */
+    suspend fun deletePost(postId: String, userId: String): Result<Unit>
+
+    /**
      * リマインド通知を送信する
      */
     suspend fun sendRemindNotification(notification: RemindNetNotification): Result<Unit>

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/remindnet/DeleteRemindNetPostUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/remindnet/DeleteRemindNetPostUseCase.kt
@@ -1,0 +1,20 @@
+package com.maropiyo.reminderparrot.domain.usecase.remindnet
+
+import com.maropiyo.reminderparrot.domain.repository.RemindNetRepository
+
+/**
+ * リマインネット投稿を削除するユースケース
+ */
+class DeleteRemindNetPostUseCase(
+    private val remindNetRepository: RemindNetRepository
+) {
+    /**
+     * 投稿を削除する
+     * @param postId 削除する投稿のID
+     * @param userId 削除を実行するユーザーのID
+     * @return 削除結果
+     */
+    suspend operator fun invoke(postId: String, userId: String): Result<Unit> {
+        return remindNetRepository.deletePost(postId, userId)
+    }
+}


### PR DESCRIPTION
## Summary
- リマインネット画面で自分の投稿を削除できる機能を実装
- 物理削除（Supabaseから完全削除）で実装
- Clean Architectureに従った全層実装
- セキュアなユーザー認証・権限制御

## 主な変更内容

### 🎯 機能実装
- **削除ボタン**: 自分の投稿詳細画面に削除ボタンを追加
- **物理削除**: 論理削除ではなくSupabaseから完全削除
- **権限制御**: 自分の投稿のみ削除可能
- **UI/UX**: 編集ボトムシートスタイルの削除ボタンデザイン

### 🏗️ アーキテクチャ
- **Domain層**: `DeleteRemindNetPostUseCase` 新規作成
- **Data層**: `RemindNetRemoteDataSource.deletePost()` 実装
- **Presentation層**: `RemindNetViewModel.deletePost()` 実装
- **UI層**: 削除ボタンと確認フローの追加

### 🔐 セキュリティ
- **RLS対応**: Supabase Row Level Security ポリシー追加
- **ユーザー認証**: JWTトークンによる所有者確認
- **権限制御**: 自分の投稿のみ削除可能

### 🐛 修正内容
- **根本原因**: Supabase RLSでDELETEポリシーが不足
- **Supabase修正**: "Users can delete own posts"ポリシーを作成・適用
- **クライアント修正**: `select()`追加で削除実行を保証

## Test plan
- [x] 自分の投稿で削除ボタンが表示される
- [x] 他人の投稿では削除ボタンが表示されない
- [x] 削除ボタン押下で投稿が完全削除される
- [x] 削除後にリストから投稿が消える
- [x] 権限のない削除操作がエラーになる
- [x] Supabase DBから実際にレコードが削除される

🤖 Generated with [Claude Code](https://claude.ai/code)