### PR TITLE
feat(remindnet): リマインネット画面にリマインコ情報表示機能を追加

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/RemindNetViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/RemindNetViewModel.kt
@@ -35,8 +35,12 @@ class RemindNetViewModel(
     private val _accountCreationError = MutableStateFlow<String?>(null)
     val accountCreationError: StateFlow<String?> = _accountCreationError.asStateFlow()
 
+    private val _displayName = MutableStateFlow<String?>(null)
+    val displayName: StateFlow<String?> = _displayName.asStateFlow()
+
     init {
         checkAccountAndLoadPosts()
+        loadDisplayName()
     }
 
     /**
@@ -239,6 +243,25 @@ class RemindNetViewModel(
                         )
                     }
                 }
+        }
+    }
+
+    /**
+     * 表示名を読み込む
+     */
+    private fun loadDisplayName() {
+        viewModelScope.launch {
+            try {
+                val currentUserId = authService.getCurrentUserId()
+                if (currentUserId != null) {
+                    val name = authService.getDisplayName()
+                    _displayName.value = name
+                } else {
+                    _displayName.value = null
+                }
+            } catch (e: Exception) {
+                _displayName.value = null
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/RemindNetViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/RemindNetViewModel.kt
@@ -38,9 +38,11 @@ class RemindNetViewModel(
     private val _displayName = MutableStateFlow<String?>(null)
     val displayName: StateFlow<String?> = _displayName.asStateFlow()
 
+    private val _isLoadingDisplayName = MutableStateFlow(false)
+    val isLoadingDisplayName: StateFlow<Boolean> = _isLoadingDisplayName.asStateFlow()
+
     init {
         checkAccountAndLoadPosts()
-        loadDisplayName()
     }
 
     /**
@@ -106,9 +108,13 @@ class RemindNetViewModel(
             val currentUserId = authService.getCurrentUserId()
             if (currentUserId == null) {
                 _needsAccountCreation.value = true
+                // アカウントがない場合は表示名もクリア
+                _displayName.value = null
             } else {
                 _needsAccountCreation.value = false
                 loadPosts()
+                // アカウントが確認できた後に表示名を読み込み
+                loadDisplayName()
             }
         }
     }
@@ -251,6 +257,7 @@ class RemindNetViewModel(
      */
     private fun loadDisplayName() {
         viewModelScope.launch {
+            _isLoadingDisplayName.value = true
             try {
                 val currentUserId = authService.getCurrentUserId()
                 if (currentUserId != null) {
@@ -261,6 +268,8 @@ class RemindNetViewModel(
                 }
             } catch (e: Exception) {
                 _displayName.value = null
+            } finally {
+                _isLoadingDisplayName.value = false
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -97,7 +97,6 @@ fun RemindNetScreen(
     val accountCreationError by remindNetViewModel.accountCreationError.collectAsState()
     val parrotState by parrotViewModel.state.collectAsState()
     val displayName by remindNetViewModel.displayName.collectAsState()
-    val isLoadingDisplayName by remindNetViewModel.isLoadingDisplayName.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
@@ -241,7 +240,6 @@ fun RemindNetScreen(
                     SimpleParrotInfoDisplay(
                         parrot = parrotState.parrot!!,
                         displayName = displayName?.takeIf { it.isNotBlank() } ?: "ひよっこインコ",
-                        isLoadingDisplayName = isLoadingDisplayName,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 16.dp, vertical = 8.dp)
@@ -838,7 +836,6 @@ private fun PostDetailCard(
 private fun SimpleParrotInfoDisplay(
     parrot: com.maropiyo.reminderparrot.domain.entity.Parrot,
     displayName: String,
-    isLoadingDisplayName: Boolean,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -867,30 +864,12 @@ private fun SimpleParrotInfoDisplay(
                 contentScale = ContentScale.Crop
             )
 
-            // 名前とレベル表示
+            // レベルと名前表示
             Column(
-                verticalArrangement = Arrangement.spacedBy(2.dp)
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
             ) {
-                if (isLoadingDisplayName) {
-                    Box(
-                        modifier = Modifier
-                            .width(80.dp)
-                            .height(16.dp)
-                            .background(
-                                Secondary.copy(alpha = 0.2f),
-                                RoundedCornerShape(8.dp)
-                            )
-                    )
-                } else {
-                    Text(
-                        text = displayName,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                        color = Secondary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
+                // レベルと名前を横並び
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -910,32 +889,18 @@ private fun SimpleParrotInfoDisplay(
                             color = Primary
                         )
                     }
-                }
-            }
-
-            // 経験値ゲージ
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
                     Text(
-                        text = "けいけんち",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = Secondary.copy(alpha = 0.7f)
-                    )
-                    Text(
-                        text = "${parrot.currentExperience}/${parrot.maxExperience}",
-                        style = MaterialTheme.typography.labelSmall,
+                        text = displayName,
+                        style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.Medium,
-                        color = Secondary.copy(alpha = 0.8f)
+                        color = Secondary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
                     )
                 }
 
+                // 経験値ゲージ
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -97,6 +97,7 @@ fun RemindNetScreen(
     val accountCreationError by remindNetViewModel.accountCreationError.collectAsState()
     val parrotState by parrotViewModel.state.collectAsState()
     val displayName by remindNetViewModel.displayName.collectAsState()
+    val isLoadingDisplayName by remindNetViewModel.isLoadingDisplayName.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
@@ -235,11 +236,12 @@ fun RemindNetScreen(
                         containerColor = White
                     )
                 )
-                // インコ情報表示
-                if (parrotState.parrot != null) {
+                // インコ情報表示（アカウントがある場合のみ）
+                if (parrotState.parrot != null && !needsAccountCreation) {
                     SimpleParrotInfoDisplay(
                         parrot = parrotState.parrot!!,
                         displayName = displayName?.takeIf { it.isNotBlank() } ?: "ひよっこインコ",
+                        isLoadingDisplayName = isLoadingDisplayName,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 16.dp, vertical = 8.dp)
@@ -836,6 +838,7 @@ private fun PostDetailCard(
 private fun SimpleParrotInfoDisplay(
     parrot: com.maropiyo.reminderparrot.domain.entity.Parrot,
     displayName: String,
+    isLoadingDisplayName: Boolean,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -868,14 +871,26 @@ private fun SimpleParrotInfoDisplay(
             Column(
                 verticalArrangement = Arrangement.spacedBy(2.dp)
             ) {
-                Text(
-                    text = displayName,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Medium,
-                    color = Secondary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
+                if (isLoadingDisplayName) {
+                    Box(
+                        modifier = Modifier
+                            .width(80.dp)
+                            .height(16.dp)
+                            .background(
+                                Secondary.copy(alpha = 0.2f),
+                                RoundedCornerShape(8.dp)
+                            )
+                    )
+                } else {
+                    Text(
+                        text = displayName,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = Secondary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp)

--- a/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/CreateReminderUseCaseTest.kt
@@ -62,6 +62,10 @@ class CreateReminderUseCaseTest {
             return Result.success(Unit)
         }
 
+        override suspend fun getExpiredReminderIds(currentTime: Instant): List<String> {
+            return emptyList()
+        }
+
         override suspend fun deleteExpiredReminders(currentTime: Instant): Int {
             return 0
         }

--- a/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/GetRemindersUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/GetRemindersUseCaseTest.kt
@@ -61,6 +61,10 @@ class GetRemindersUseCaseTest {
             return Result.success(Unit)
         }
 
+        override suspend fun getExpiredReminderIds(currentTime: Instant): List<String> {
+            return emptyList()
+        }
+
         override suspend fun deleteExpiredReminders(currentTime: Instant): Int {
             return 0
         }

--- a/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/UpdateReminderUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/maropiyo/reminderparrot/domain/usecase/UpdateReminderUseCaseTest.kt
@@ -59,6 +59,10 @@ class UpdateReminderUseCaseTest {
             return Result.success(Unit)
         }
 
+        override suspend fun getExpiredReminderIds(currentTime: Instant): List<String> {
+            return emptyList()
+        }
+
         override suspend fun deleteExpiredReminders(currentTime: Instant): Int {
             return 0
         }


### PR DESCRIPTION
## Summary
- リマインネット画面にリマインコのアイコン、ユーザー名、レベル、経験値ゲージを表示
- 角丸デザインでかわいく親しみやすいUIに改善
- AuthServiceからユーザー名を取得し、未設定時は「ひよっこインコ」を表示
- カスタム経験値ゲージでグラデーション効果を実装

## Test plan
- [x] リマインネット画面でリマインコ情報が正しく表示されること
- [x] ユーザー名が正しく取得・表示されること
- [x] レベルと経験値が正しく表示されること
- [x] 経験値ゲージの進捗が正確に反映されること
- [x] 角丸デザインが適切に表示されること
- [x] 全テストが通ること
- [x] コードスタイルがktlintに準拠していること

🤖 Generated with [Claude Code](https://claude.ai/code)