### PR TITLE
feat(remindnet): リマインド送信時の経験値加算とアニメーション機能を追加

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
@@ -48,7 +48,7 @@ val appModule =
             ReminderListViewModel(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get())
         }
         single<ParrotViewModel> { ParrotViewModel(get()) }
-        single<RemindNetViewModel> { RemindNetViewModel(get(), get(), get(), get(), get()) }
+        single<RemindNetViewModel> { RemindNetViewModel(get(), get(), get(), get(), get(), get(), get()) }
         single<SettingsViewModel> { SettingsViewModel(get(), get(), get()) }
 
         // UseCase


### PR DESCRIPTION
## Summary
- ✨ リマインド送信成功時に経験値+1を自動付与
- 🎯 リアルタイムUI更新でアプリ再起動不要
- 🎨 ホーム画面と同等の高品質経験値ゲージアニメーション
- 🎉 レベルアップ時の祝いポップアップ表示

## Test plan
- [ ] リマインネット画面でカード内ベルボタンからリマインド送信
- [ ] ボトムシート内ベルボタンからリマインド送信
- [ ] 経験値ゲージのスムーズなアニメーション確認
- [ ] レベルアップ時のポップアップ表示確認
- [ ] エラー時の適切なハンドリング確認

🤖 Generated with [Claude Code](https://claude.ai/code)