### PR TITLE
feat: リマインダー登録時の経験値加算の安定性向上とエラーボトムシート実装

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ReminderListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/ReminderListViewModel.kt
@@ -67,8 +67,9 @@ class ReminderListViewModel(
      * リマインダーを作成する
      *
      * @param text リマインダーのテキスト
+     * @param onExperienceAdded 経験値加算完了時のコールバック
      */
-    fun createReminder(text: String) {
+    fun createReminder(text: String, onExperienceAdded: (() -> Unit)? = null) {
         viewModelScope.launch {
             createReminderUseCase(text)
                 .onSuccess { reminder ->
@@ -83,6 +84,16 @@ class ReminderListViewModel(
                     }
                     // インコの経験値を追加（+1）
                     addParrotExperienceUseCase()
+                        .onSuccess {
+                            // 経験値加算成功時のコールバック実行
+                            onExperienceAdded?.invoke()
+                        }
+                        .onFailure { exception ->
+                            // 経験値加算失敗をログに記録（UI表示はしない）
+                            println("経験値加算に失敗しました: ${exception.message}")
+                            // 失敗してもコールバックは実行する（リマインダー作成自体は成功）
+                            onExperienceAdded?.invoke()
+                        }
 
                     // 設定を確認してリマインネットに投稿するかどうかを決める
                     val settings = getUserSettingsUseCase()

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ReminderContent.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import com.maropiyo.reminderparrot.domain.entity.Reminder
 import com.maropiyo.reminderparrot.presentation.state.ParrotState
 import com.maropiyo.reminderparrot.presentation.state.ReminderListState
+import com.maropiyo.reminderparrot.ui.components.ErrorMessageBottomSheet
 import com.maropiyo.reminderparrot.ui.components.common.CountdownText
 import com.maropiyo.reminderparrot.ui.components.state.EmptyState
 import com.maropiyo.reminderparrot.ui.components.state.ErrorState
@@ -89,6 +90,8 @@ fun ReminderContent(
     var isShowBottomSheet by remember { mutableStateOf(false) }
     // 編集ボトムシートの表示状態
     var isShowEditBottomSheet by remember { mutableStateOf(false) }
+    // エラーボトムシートの表示状態
+    var showErrorBottomSheet by remember { mutableStateOf(false) }
     // 編集中のリマインダー
     var editingReminder by remember { mutableStateOf<Reminder?>(null) }
     // リマインダーテキスト
@@ -97,6 +100,8 @@ fun ReminderContent(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     // 編集ボトムシートの状態
     val editSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    // エラーボトムシートの状態
+    val errorSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     // コルーチンスコープとキーボードコントローラーの取得
     val scope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -130,8 +135,13 @@ fun ReminderContent(
         // フローティングアクションボタン
         ReminderFloatingActionButton(
             onClick = {
-                reminderText = ""
-                isShowBottomSheet = true
+                // リマインダー数が上限に達しているかチェック
+                if (state.reminders.size >= parrotState.parrot.memorizedWords) {
+                    showErrorBottomSheet = true
+                } else {
+                    reminderText = ""
+                    isShowBottomSheet = true
+                }
             },
             modifier =
             Modifier
@@ -189,6 +199,21 @@ fun ReminderContent(
                     }
                 },
                 sheetState = editSheetState
+            )
+        }
+
+        // エラーボトムシート
+        if (showErrorBottomSheet) {
+            ErrorMessageBottomSheet(
+                title = "もうおぼえられないよ〜",
+                message = "レベルをあげてもっとかしこくなろう！",
+                onDismiss = {
+                    scope.launch {
+                        errorSheetState.hide()
+                        showErrorBottomSheet = false
+                    }
+                },
+                sheetState = errorSheetState
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/HomeScreen.kt
@@ -81,9 +81,10 @@ fun HomeScreen(
                     parrotViewModel.loadParrot()
                 },
                 onCreateReminder = { text, _ ->
-                    reminderListViewModel.createReminder(text)
-                    // リマインダー作成後にインコの状態を再読み込み
-                    parrotViewModel.loadParrot()
+                    reminderListViewModel.createReminder(text) {
+                        // 経験値加算完了後にインコの状態を再読み込み
+                        parrotViewModel.loadParrot()
+                    }
                 },
                 onUpdateReminder = { reminderId, newText ->
                     reminderListViewModel.updateReminderText(reminderId, newText)


### PR DESCRIPTION
## Summary
- リマインダー登録時の経験値加算が不安定な問題を修正
- ホーム画面でリマインダー追加ボタンクリック時に上限チェックを実装
- 上限達成時に「もうおぼえられないよ〜」エラーボトムシートを表示

## Changes
### 🔧 経験値加算の安定性向上
- `ReminderListViewModel.createReminder`にエラーハンドリングを追加
- 経験値加算失敗時のログ出力を実装
- コールバック機能で経験値加算完了後の状態同期を改善

### 🎨 UI改善
- ホーム画面のリマインダー追加ボタンに上限チェック機能を追加
- 上限達成時に「もうおぼえられないよ〜」エラーボトムシートを表示
- 既存のErrorMessageBottomSheetコンポーネントを活用

### 🔄 非同期処理改善
- 経験値加算完了後にParrotViewModelの状態を再読み込み
- UI表示の一貫性向上とタイミング問題を解決

## Test plan
- [x] 全テストが正常に実行されることを確認
- [x] コードフォーマットとlintチェックが通ることを確認
- [x] Androidデバッグビルドが正常にコンパイルされることを確認
- [ ] 実機でのリマインダー登録時の経験値加算動作確認
- [ ] 上限達成時のエラーボトムシート表示確認

## Related Issue
リマインダー登録時に経験値が加算されない場合がある問題の修正

🤖 Generated with [Claude Code](https://claude.ai/code)