### PR TITLE
feat: リマインドネット登録直後のアカウントに初期DisplayName「ひよっこインコ」を自動設定

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/service/AuthServiceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/service/AuthServiceImpl.kt
@@ -27,7 +27,19 @@ class AuthServiceImpl(
         // 匿名認証を実行
         supabaseClient.auth.signInAnonymously()
         val authenticatedUser = supabaseClient.auth.currentUserOrNull()
-        return@withLock authenticatedUser?.id ?: throw IllegalStateException("匿名認証に失敗しました")
+        val userId = authenticatedUser?.id ?: throw IllegalStateException("匿名認証に失敗しました")
+
+        // 新規ユーザーの場合、初期表示名を設定
+        try {
+            val currentDisplayName = getDisplayName()
+            if (currentDisplayName.isNullOrBlank()) {
+                updateDisplayName("ひよっこインコ")
+            }
+        } catch (e: Exception) {
+            // 初期名設定失敗は無視（認証自体は成功）
+        }
+
+        return@withLock userId
     }
 
     override suspend fun getCurrentUserId(): String? {

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/SettingsViewModel.kt
@@ -215,11 +215,8 @@ class SettingsViewModel(
                 // エラーをクリア
                 _accountCreationError.value = null
 
-                // 匿名認証でアカウントを作成
+                // 匿名認証でアカウントを作成（初期名は自動設定される）
                 authService.getUserId()
-
-                // 初期名を設定
-                authService.updateDisplayName("ひよっこインコ")
 
                 // ユーザーIDを再読み込み
                 loadUserId()


### PR DESCRIPTION
## Summary
リマインドネット登録直後のアカウントでDisplayNameが設定されていない問題を修正し、自動的に「ひよっこインコ」を初期値として設定するように改善しました。

## Problem
- リマインドネット登録直後のアカウントでDisplayNameがnullになっている
- SettingsViewModelでは初期値設定されているが、RemindNetViewModelでは設定されていない
- 一貫性のない初期値設定により、ユーザー体験が不安定

## Solution
### 🔧 AuthServiceImplの改善
- `getUserId()`メソッドで新規ユーザー作成時に自動的に「ひよっこインコ」を初期値として設定
- 既存のDisplayNameがnullまたは空文字の場合のみ初期値を設定
- 初期値設定に失敗してもアカウント作成は継続される安全な実装

### 🎨 SettingsViewModelの簡略化
- 重複した初期値設定処理を削除
- 責任を適切に分離し、AuthServiceに委譲
- コードの重複を削除し、保守性を向上

## Benefits
- **一貫性の向上**: SettingsViewModelとRemindNetViewModelの両方で同じ初期値が設定される
- **コードの簡潔化**: 重複した処理を削除し、責任を適切に分離
- **エラー対応**: 初期値設定に失敗してもアカウント作成は継続される
- **保守性向上**: 初期値設定ロジックが1箇所に集約される

## Test plan
- [x] 全テストが正常に実行されることを確認
- [x] コードフォーマットとlintチェックが通ることを確認
- [x] AndroidおよびiOSビルドが正常に完了することを確認
- [ ] 実機でのリマインドネット新規登録時のDisplayName設定確認
- [ ] 既存アカウントでのDisplayName取得動作確認

## Changes
- `AuthServiceImpl.getUserId()`: 新規ユーザー作成時の自動初期値設定を追加
- `SettingsViewModel.createAccount()`: 重複した初期値設定処理を削除

🤖 Generated with [Claude Code](https://claude.ai/code)