### PR TITLE
feat(ui): リマインネット参加フローを2段階に簡素化と削除処理改善

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/RemindNetViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/RemindNetViewModel.kt
@@ -291,6 +291,31 @@ class RemindNetViewModel(
      * 表示名を読み込む
      */
     private fun loadDisplayName() {
+        // 既にローディング中または既に取得済みの場合はスキップ
+        if (_isLoadingDisplayName.value || _displayName.value != null) return
+        
+        viewModelScope.launch {
+            _isLoadingDisplayName.value = true
+            try {
+                val currentUserId = authService.getCurrentUserId()
+                if (currentUserId != null) {
+                    val name = authService.getDisplayName()
+                    _displayName.value = name
+                } else {
+                    _displayName.value = null
+                }
+            } catch (e: Exception) {
+                _displayName.value = null
+            } finally {
+                _isLoadingDisplayName.value = false
+            }
+        }
+    }
+
+    /**
+     * 表示名を強制的に再読み込みする
+     */
+    fun forceReloadDisplayName() {
         viewModelScope.launch {
             _isLoadingDisplayName.value = true
             try {

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/RemindNetViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/RemindNetViewModel.kt
@@ -293,7 +293,7 @@ class RemindNetViewModel(
     private fun loadDisplayName() {
         // 既にローディング中または既に取得済みの場合はスキップ
         if (_isLoadingDisplayName.value || _displayName.value != null) return
-        
+
         viewModelScope.launch {
             _isLoadingDisplayName.value = true
             try {

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/presentation/viewmodel/SettingsViewModel.kt
@@ -82,7 +82,7 @@ class SettingsViewModel(
     private fun loadDisplayName() {
         // 既にローディング中または既に取得済みの場合はスキップ
         if (_isLoadingDisplayName.value || _displayName.value != null) return
-        
+
         viewModelScope.launch {
             _isLoadingDisplayName.value = true
             try {

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/AccountCreationBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/AccountCreationBottomSheet.kt
@@ -96,22 +96,6 @@ fun AccountCreationBottomSheet(
                     )
                 2 ->
                     FunctionExplanationCard(
-                        onNext = { currentStep = 3 },
-                        modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(top = 104.dp)
-                    )
-                3 ->
-                    RulesCard(
-                        onNext = { currentStep = 4 },
-                        modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(top = 104.dp)
-                    )
-                4 ->
-                    FinalConfirmationCard(
                         onCreateAccount = onCreateAccount,
                         errorMessage = errorMessage,
                         modifier =
@@ -167,7 +151,7 @@ private fun ParticipationConfirmationCard(onNext: () -> Unit, modifier: Modifier
 
             // 説明テキスト
             Text(
-                text = "リマインネットはインコどうしで\nおぼえたことばをきょうゆうするきのうだよ！",
+                text = "リマインネットはインコたちが\nおぼえたことばを共有する場所だよ！",
                 color = Secondary.copy(alpha = 0.8f),
                 style = MaterialTheme.typography.bodyMedium,
                 textAlign = TextAlign.Center,
@@ -193,7 +177,11 @@ private fun ParticipationConfirmationCard(onNext: () -> Unit, modifier: Modifier
  * 第2段階：機能説明カード
  */
 @Composable
-private fun FunctionExplanationCard(onNext: () -> Unit, modifier: Modifier = Modifier) {
+private fun FunctionExplanationCard(
+    onCreateAccount: () -> Unit,
+    errorMessage: String? = null,
+    modifier: Modifier = Modifier
+) {
     Card(
         modifier = modifier,
         colors =
@@ -298,125 +286,13 @@ private fun FunctionExplanationCard(onNext: () -> Unit, modifier: Modifier = Mod
                     }
                     Spacer(Modifier.width(12.dp))
                     Text(
-                        text = "気に入ったことばを\nじぶんのインコにおぼえさせることができるよ",
+                        text = "おもいだしたことばを\nじぶんのインコにおぼえさせられるよ",
                         color = Secondary.copy(alpha = 0.8f),
                         style = MaterialTheme.typography.bodyMedium,
                         lineHeight = MaterialTheme.typography.bodyMedium.lineHeight
                     )
                 }
             }
-
-            Spacer(Modifier.height(24.dp))
-
-            // つぎボタン
-            NextButton(
-                onClick = onNext,
-                modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .height(50.dp)
-            )
-        }
-    }
-}
-
-/**
- * 第3段階：ルールカード
- */
-@Composable
-private fun RulesCard(onNext: () -> Unit, modifier: Modifier = Modifier) {
-    Card(
-        modifier = modifier,
-        colors =
-        CardDefaults.cardColors(
-            containerColor = Background
-        ),
-        shape = Shapes.extraLarge
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(vertical = 24.dp)
-        ) {
-            // タイトルテキスト
-            Text(
-                text = "やくそく",
-                color = Secondary,
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold
-            )
-
-            Spacer(Modifier.height(16.dp))
-
-            // 注意事項
-            Text(
-                text = "みんなでたのしくつかうために\nふてきせつなことはしないようにしよう！",
-                color = Secondary.copy(alpha = 0.8f),
-                style = MaterialTheme.typography.bodyMedium,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(horizontal = 16.dp)
-            )
-
-            Spacer(Modifier.height(24.dp))
-
-            // つぎボタン
-            NextButton(
-                onClick = onNext,
-                modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .height(50.dp)
-            )
-        }
-    }
-}
-
-/**
- * 第4段階：最終確認カード
- */
-@Composable
-private fun FinalConfirmationCard(
-    onCreateAccount: () -> Unit,
-    errorMessage: String? = null,
-    modifier: Modifier = Modifier
-) {
-    Card(
-        modifier = modifier,
-        colors =
-        CardDefaults.cardColors(
-            containerColor = Background
-        ),
-        shape = Shapes.extraLarge
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(vertical = 24.dp)
-        ) {
-            // タイトルテキスト
-            Text(
-                text = "じゅんびかんりょう！",
-                color = Secondary,
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold
-            )
-
-            Spacer(Modifier.height(16.dp))
-
-            // 説明テキスト
-            Text(
-                text = "リマインネットをはじめよう",
-                color = Secondary.copy(alpha = 0.8f),
-                style = MaterialTheme.typography.bodyMedium,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(horizontal = 16.dp)
-            )
 
             Spacer(Modifier.height(24.dp))
 
@@ -479,7 +355,7 @@ private fun CreateAccountButton(onClick: () -> Unit, modifier: Modifier = Modifi
         shape = Shapes.large,
         colors =
         ButtonDefaults.elevatedButtonColors(
-            containerColor = Secondary,
+            containerColor = Primary,
             contentColor = White
         )
     ) {

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/AccountCreationBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/AccountCreationBottomSheet.kt
@@ -1,31 +1,50 @@
 package com.maropiyo.reminderparrot.ui.components
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedButton
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.maropiyo.reminderparrot.ui.icons.CustomIcons
 import com.maropiyo.reminderparrot.ui.theme.Background
+import com.maropiyo.reminderparrot.ui.theme.ParrotYellow
+import com.maropiyo.reminderparrot.ui.theme.Primary
 import com.maropiyo.reminderparrot.ui.theme.Secondary
 import com.maropiyo.reminderparrot.ui.theme.Shapes
 import com.maropiyo.reminderparrot.ui.theme.White
@@ -49,6 +68,9 @@ fun AccountCreationBottomSheet(
     sheetState: androidx.compose.material3.SheetState,
     errorMessage: String? = null
 ) {
+    // 段階管理のstate
+    var currentStep by remember { mutableStateOf(1) }
+
     ModalBottomSheet(
         dragHandle = null,
         onDismissRequest = onDismiss,
@@ -56,25 +78,55 @@ fun AccountCreationBottomSheet(
         containerColor = Color.Transparent
     ) {
         Box(
-            modifier = Modifier
+            modifier =
+            Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp)
                 .padding(bottom = 16.dp)
                 .imePadding()
         ) {
-            AccountCreationCard(
-                onCreateAccount = onCreateAccount,
-                errorMessage = errorMessage,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 104.dp)
-            )
+            when (currentStep) {
+                1 ->
+                    ParticipationConfirmationCard(
+                        onNext = { currentStep = 2 },
+                        modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = 104.dp)
+                    )
+                2 ->
+                    FunctionExplanationCard(
+                        onNext = { currentStep = 3 },
+                        modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = 104.dp)
+                    )
+                3 ->
+                    RulesCard(
+                        onNext = { currentStep = 4 },
+                        modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = 104.dp)
+                    )
+                4 ->
+                    FinalConfirmationCard(
+                        onCreateAccount = onCreateAccount,
+                        errorMessage = errorMessage,
+                        modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = 104.dp)
+                    )
+            }
 
             // インコの画像
             Image(
                 painter = painterResource(Res.drawable.reminko_raising_hand),
                 contentDescription = "インコ",
-                modifier = Modifier
+                modifier =
+                Modifier
                     .size(128.dp)
                     .align(Alignment.TopCenter),
                 contentScale = ContentScale.Crop
@@ -84,30 +136,28 @@ fun AccountCreationBottomSheet(
 }
 
 /**
- * アカウント作成カード
+ * 第1段階：参加確認カード
  */
 @Composable
-private fun AccountCreationCard(
-    onCreateAccount: () -> Unit,
-    errorMessage: String? = null,
-    modifier: Modifier = Modifier
-) {
+private fun ParticipationConfirmationCard(onNext: () -> Unit, modifier: Modifier = Modifier) {
     Card(
         modifier = modifier,
-        colors = CardDefaults.cardColors(
+        colors =
+        CardDefaults.cardColors(
             containerColor = Background
         ),
         shape = Shapes.extraLarge
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
+            modifier =
+            Modifier
                 .fillMaxWidth()
                 .padding(vertical = 24.dp)
         ) {
             // タイトルテキスト
             Text(
-                text = "リマインネットをつかうよ！",
+                text = "リマインネットに参加する？",
                 color = Secondary,
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold
@@ -117,7 +167,7 @@ private fun AccountCreationCard(
 
             // 説明テキスト
             Text(
-                text = "リマインネットはインコどうしで\nことばをきょうゆうするきのうだよ！",
+                text = "リマインネットはインコどうしで\nおぼえたことばをきょうゆうするきのうだよ！",
                 color = Secondary.copy(alpha = 0.8f),
                 style = MaterialTheme.typography.bodyMedium,
                 textAlign = TextAlign.Center,
@@ -126,10 +176,255 @@ private fun AccountCreationCard(
 
             Spacer(Modifier.height(24.dp))
 
-            // アカウント作成ボタン
+            // つぎボタン
+            NextButton(
+                onClick = onNext,
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .height(50.dp)
+            )
+        }
+    }
+}
+
+/**
+ * 第2段階：機能説明カード
+ */
+@Composable
+private fun FunctionExplanationCard(onNext: () -> Unit, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier,
+        colors =
+        CardDefaults.cardColors(
+            containerColor = Background
+        ),
+        shape = Shapes.extraLarge
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 24.dp)
+        ) {
+            // タイトルテキスト
+            Text(
+                text = "つかいかた",
+                color = Secondary,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            // 機能説明
+            Column(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                // リマインドボタンの説明
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Box(
+                        modifier =
+                        Modifier
+                            .size(40.dp)
+                            .background(
+                                color = ParrotYellow,
+                                shape = CircleShape
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Notifications,
+                            contentDescription = null,
+                            tint = White,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                    Spacer(Modifier.width(12.dp))
+                    Text(
+                        text = "ほかのインコにリマインドを\nおくることができるよ",
+                        color = Secondary.copy(alpha = 0.8f),
+                        style = MaterialTheme.typography.bodyMedium,
+                        lineHeight = MaterialTheme.typography.bodyMedium.lineHeight
+                    )
+                }
+
+                // おぼえるボタンの説明
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Box(
+                        modifier =
+                        Modifier
+                            .size(40.dp)
+                            .background(
+                                color = White,
+                                shape = CircleShape
+                            ),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        // 点線の円を描画
+                        Canvas(modifier = Modifier.size(40.dp)) {
+                            val strokeWidth = 2.dp.toPx()
+                            val radius = (size.minDimension - strokeWidth) / 2
+                            val center = Offset(size.width / 2, size.height / 2)
+
+                            drawCircle(
+                                color = Primary,
+                                radius = radius,
+                                center = center,
+                                style =
+                                Stroke(
+                                    width = strokeWidth,
+                                    pathEffect = PathEffect.dashPathEffect(floatArrayOf(8f, 6f), 0f)
+                                )
+                            )
+                        }
+
+                        // 下矢印アイコン
+                        Icon(
+                            imageVector = CustomIcons.ArrowDownward,
+                            contentDescription = null,
+                            tint = Primary,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                    Spacer(Modifier.width(12.dp))
+                    Text(
+                        text = "気に入ったことばを\nじぶんのインコにおぼえさせることができるよ",
+                        color = Secondary.copy(alpha = 0.8f),
+                        style = MaterialTheme.typography.bodyMedium,
+                        lineHeight = MaterialTheme.typography.bodyMedium.lineHeight
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            // つぎボタン
+            NextButton(
+                onClick = onNext,
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .height(50.dp)
+            )
+        }
+    }
+}
+
+/**
+ * 第3段階：ルールカード
+ */
+@Composable
+private fun RulesCard(onNext: () -> Unit, modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier,
+        colors =
+        CardDefaults.cardColors(
+            containerColor = Background
+        ),
+        shape = Shapes.extraLarge
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 24.dp)
+        ) {
+            // タイトルテキスト
+            Text(
+                text = "やくそく",
+                color = Secondary,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            // 注意事項
+            Text(
+                text = "みんなでたのしくつかうために\nふてきせつなことはしないようにしよう！",
+                color = Secondary.copy(alpha = 0.8f),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            // つぎボタン
+            NextButton(
+                onClick = onNext,
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .height(50.dp)
+            )
+        }
+    }
+}
+
+/**
+ * 第4段階：最終確認カード
+ */
+@Composable
+private fun FinalConfirmationCard(
+    onCreateAccount: () -> Unit,
+    errorMessage: String? = null,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier,
+        colors =
+        CardDefaults.cardColors(
+            containerColor = Background
+        ),
+        shape = Shapes.extraLarge
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 24.dp)
+        ) {
+            // タイトルテキスト
+            Text(
+                text = "じゅんびかんりょう！",
+                color = Secondary,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            // 説明テキスト
+            Text(
+                text = "リマインネットをはじめよう",
+                color = Secondary.copy(alpha = 0.8f),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            // さんかするボタン
             CreateAccountButton(
                 onClick = onCreateAccount,
-                modifier = Modifier
+                modifier =
+                Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp)
                     .height(50.dp)
@@ -151,7 +446,30 @@ private fun AccountCreationCard(
 }
 
 /**
- * アカウント作成ボタン
+ * つぎボタン
+ */
+@Composable
+private fun NextButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    ElevatedButton(
+        onClick = onClick,
+        modifier = modifier,
+        shape = Shapes.large,
+        colors =
+        ButtonDefaults.elevatedButtonColors(
+            containerColor = Primary,
+            contentColor = White
+        )
+    ) {
+        Text(
+            text = "つぎ",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+/**
+ * さんかするボタン
  */
 @Composable
 private fun CreateAccountButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
@@ -159,13 +477,14 @@ private fun CreateAccountButton(onClick: () -> Unit, modifier: Modifier = Modifi
         onClick = onClick,
         modifier = modifier,
         shape = Shapes.large,
-        colors = ButtonDefaults.elevatedButtonColors(
+        colors =
+        ButtonDefaults.elevatedButtonColors(
             containerColor = Secondary,
             contentColor = White
         )
     ) {
         Text(
-            text = "つかってみる",
+            text = "さんかする",
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.Bold
         )

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -730,7 +730,7 @@ private fun CircularBellButton(onClick: () -> Unit, modifier: Modifier = Modifie
     ) {
         Icon(
             imageVector = Icons.Default.Notifications,
-            contentDescription = "リマインドを送る",
+            contentDescription = "リマインドをおくる",
             tint = White,
             modifier = Modifier.size(18.dp)
         )
@@ -1017,12 +1017,12 @@ private fun PostDetailCard(
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Notifications,
-                                contentDescription = "リマインドを送る",
+                                contentDescription = "リマインドをおくる",
                                 modifier = Modifier.size(20.dp)
                             )
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
-                                text = "リマインドを送る",
+                                text = "リマインドをおくる",
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold
                             )

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -596,15 +596,39 @@ private fun RemindNetPostCard(
                 Column(
                     modifier = Modifier.weight(1f)
                 ) {
-                    // ユーザー名
-                    Text(
-                        text = post.userName,
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.Bold,
-                        color = Secondary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        // ユーザー名
+                        Text(
+                            text = post.userName,
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = Secondary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+
+                        // あなたの投稿
+                        if (isMyPost) {
+                            Box(
+                                modifier = Modifier
+                                    .background(
+                                        color = Secondary.copy(alpha = 0.1f),
+                                        shape = RoundedCornerShape(16.dp)
+                                    )
+                                    .padding(horizontal = 8.dp, vertical = 4.dp)
+                            ) {
+                                Text(
+                                    text = "あなた",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = Secondary,
+                                    fontWeight = FontWeight.Medium
+                                )
+                            }
+                        }
+                    }
 
                     // 投稿時間
                     Text(
@@ -896,13 +920,37 @@ private fun PostDetailCard(
                 Column(
                     modifier = Modifier.weight(1f)
                 ) {
-                    // ユーザー名
-                    Text(
-                        text = post.userName,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = Secondary
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        // ユーザー名
+                        Text(
+                            text = post.userName,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = Secondary
+                        )
+
+                        // スマートな投稿者表示
+                        if (isMyPost) {
+                            Box(
+                                modifier = Modifier
+                                    .background(
+                                        color = Secondary.copy(alpha = 0.1f),
+                                        shape = RoundedCornerShape(16.dp)
+                                    )
+                                    .padding(horizontal = 12.dp, vertical = 6.dp)
+                            ) {
+                                Text(
+                                    text = "あなた",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = Secondary,
+                                    fontWeight = FontWeight.Medium
+                                )
+                            }
+                        }
+                    }
 
                     // 投稿時間
                     Text(
@@ -1027,26 +1075,6 @@ private fun PostDetailCard(
                         .padding(horizontal = 16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    // スマートな投稿者表示
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(bottom = 16.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Person,
-                            contentDescription = null,
-                            tint = Secondary,
-                            modifier = Modifier.size(16.dp)
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Text(
-                            text = "あなたの投稿",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = Secondary,
-                            fontWeight = FontWeight.Medium
-                        )
-                    }
-
                     // 編集ボトムシートスタイルの削除ボタン
                     ElevatedButton(
                         onClick = { onDeleteClick(post) },
@@ -1062,7 +1090,7 @@ private fun PostDetailCard(
                         )
                     ) {
                         Text(
-                            text = "わすれる",
+                            text = "さくじょ",
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold
                         )

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -467,14 +467,14 @@ fun RemindNetScreen(
                 },
                 onDeleteClick = { clickedPost ->
                     println("RemindNetScreen: 削除ボタンクリック - postId: ${clickedPost.id}")
+                    // 削除処理開始時に即座にボトムシートを閉じる
+                    scope.launch {
+                        postDetailSheetState.hide()
+                        showPostDetailBottomSheet = false
+                        selectedPost = null
+                    }
                     remindNetViewModel.deletePost(clickedPost.id) {
                         println("RemindNetScreen: 削除成功コールバック実行")
-                        // 削除成功時にボトムシートを閉じる
-                        scope.launch {
-                            postDetailSheetState.hide()
-                            showPostDetailBottomSheet = false
-                            selectedPost = null
-                        }
                     }
                 },
                 sheetState = postDetailSheetState,
@@ -1004,7 +1004,7 @@ private fun PostDetailCard(
                 ) {
                     // リマインドボタン
                     ElevatedButton(
-                        onClick = { 
+                        onClick = {
                             if (!isAlreadySent) {
                                 onBellClick(post)
                             }
@@ -1038,7 +1038,7 @@ private fun PostDetailCard(
 
                     // インポートボタン
                     ElevatedButton(
-                        onClick = { 
+                        onClick = {
                             if (!isAlreadyImported) {
                                 onImportClick(post)
                             }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Notifications
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -67,7 +66,6 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.maropiyo.reminderparrot.domain.entity.RemindNetPost
@@ -108,6 +106,7 @@ fun RemindNetScreen(
     val accountCreationError by remindNetViewModel.accountCreationError.collectAsState()
     val parrotState by parrotViewModel.state.collectAsState()
     val displayName by remindNetViewModel.displayName.collectAsState()
+    val isLoadingDisplayName by remindNetViewModel.isLoadingDisplayName.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
@@ -161,6 +160,8 @@ fun RemindNetScreen(
     // 画面に遷移した時に投稿を再取得
     LaunchedEffect(Unit) {
         remindNetViewModel.onScreenEntered()
+        // 他の画面で名前が変更されている可能性があるため強制的に再読み込み
+        remindNetViewModel.forceReloadDisplayName()
     }
 
     // レベルアップを検出
@@ -285,6 +286,7 @@ fun RemindNetScreen(
                     SimpleParrotInfoDisplay(
                         parrot = parrotState.parrot!!,
                         displayName = displayName?.takeIf { it.isNotBlank() } ?: "ひよっこインコ",
+                        isLoadingDisplayName = isLoadingDisplayName,
                         modifier =
                         Modifier
                             .fillMaxWidth()
@@ -1099,6 +1101,7 @@ private fun PostDetailCard(
 private fun SimpleParrotInfoDisplay(
     parrot: com.maropiyo.reminderparrot.domain.entity.Parrot,
     displayName: String,
+    isLoadingDisplayName: Boolean = false,
     modifier: Modifier = Modifier
 ) {
     Card(
@@ -1155,15 +1158,27 @@ private fun SimpleParrotInfoDisplay(
                             color = Primary
                         )
                     }
-                    Text(
-                        text = displayName,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                        color = Secondary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f)
-                    )
+                    if (isLoadingDisplayName && displayName == null) {
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(16.dp)
+                                .background(
+                                    Secondary.copy(alpha = 0.1f),
+                                    RoundedCornerShape(8.dp)
+                                )
+                        )
+                    } else {
+                        Text(
+                            text = displayName,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = Secondary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
                 }
 
                 // 経験値ゲージ（アニメーション付き）

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -1027,15 +1027,6 @@ private fun PostDetailCard(
                                 fontWeight = FontWeight.Bold
                             )
                         }
-                    } else {
-                        Text(
-                            text = "リマインドを送信済み",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = Secondary.copy(alpha = 0.6f),
-                            fontWeight = FontWeight.Medium,
-                            modifier = Modifier.fillMaxWidth(),
-                            textAlign = TextAlign.Center
-                        )
                     }
 
                     // インポートボタン（未インポートのみ表示）

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -1002,62 +1002,72 @@ private fun PostDetailCard(
                         .padding(horizontal = 16.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
-                    // リマインドボタン（未送信のみ）
-                    if (!isAlreadySent) {
-                        ElevatedButton(
-                            onClick = { onBellClick(post) },
-                            modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .height(50.dp),
-                            shape = Shapes.large,
-                            colors =
-                            ButtonDefaults.elevatedButtonColors(
-                                containerColor = ParrotYellow,
-                                contentColor = White
-                            )
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Notifications,
-                                contentDescription = "リマインドをおくる",
-                                modifier = Modifier.size(20.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(
-                                text = "リマインドをおくる",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
+                    // リマインドボタン
+                    ElevatedButton(
+                        onClick = { 
+                            if (!isAlreadySent) {
+                                onBellClick(post)
+                            }
+                        },
+                        modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(50.dp),
+                        shape = Shapes.large,
+                        enabled = !isAlreadySent,
+                        colors =
+                        ButtonDefaults.elevatedButtonColors(
+                            containerColor = if (isAlreadySent) ParrotYellow.copy(alpha = 0.3f) else ParrotYellow,
+                            contentColor = if (isAlreadySent) White.copy(alpha = 0.5f) else White,
+                            disabledContainerColor = ParrotYellow.copy(alpha = 0.3f),
+                            disabledContentColor = White.copy(alpha = 0.5f)
+                        )
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Notifications,
+                            contentDescription = "リマインドをおくる",
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = if (isAlreadySent) "リマインドそうしんずみ" else "リマインドをおくる",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold
+                        )
                     }
 
-                    // インポートボタン（未インポートのみ表示）
-                    if (!isAlreadyImported) {
-                        ElevatedButton(
-                            onClick = { onImportClick(post) },
-                            modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .height(50.dp),
-                            shape = Shapes.large,
-                            colors =
-                            ButtonDefaults.elevatedButtonColors(
-                                containerColor = Primary,
-                                contentColor = White
-                            )
-                        ) {
-                            Icon(
-                                imageVector = CustomIcons.ArrowDownward,
-                                contentDescription = "ことばをおぼえる",
-                                modifier = Modifier.size(20.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(
-                                text = "このことばをおぼえる",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
+                    // インポートボタン
+                    ElevatedButton(
+                        onClick = { 
+                            if (!isAlreadyImported) {
+                                onImportClick(post)
+                            }
+                        },
+                        modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(50.dp),
+                        shape = Shapes.large,
+                        enabled = !isAlreadyImported,
+                        colors =
+                        ButtonDefaults.elevatedButtonColors(
+                            containerColor = if (isAlreadyImported) Primary.copy(alpha = 0.3f) else Primary,
+                            contentColor = if (isAlreadyImported) White.copy(alpha = 0.5f) else White,
+                            disabledContainerColor = Primary.copy(alpha = 0.3f),
+                            disabledContentColor = White.copy(alpha = 0.5f)
+                        )
+                    ) {
+                        Icon(
+                            imageVector = CustomIcons.ArrowDownward,
+                            contentDescription = "ことばをおぼえる",
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = if (isAlreadyImported) "おぼえてるよ" else "このことばをおぼえる",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold
+                        )
                     }
                 }
             } else {

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -466,7 +466,6 @@ fun RemindNetScreen(
                     }
                 },
                 onDeleteClick = { clickedPost ->
-                    println("RemindNetScreen: 削除ボタンクリック - postId: ${clickedPost.id}")
                     // 削除処理開始時に即座にボトムシートを閉じる
                     scope.launch {
                         postDetailSheetState.hide()
@@ -474,7 +473,7 @@ fun RemindNetScreen(
                         selectedPost = null
                     }
                     remindNetViewModel.deletePost(clickedPost.id) {
-                        println("RemindNetScreen: 削除成功コールバック実行")
+                        // 削除成功時の処理（必要に応じてトースト表示など）
                     }
                 },
                 sheetState = postDetailSheetState,

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/SettingsScreen.kt
@@ -70,6 +70,7 @@ fun SettingsScreen() {
     val settings by viewModel.settings.collectAsState()
     val userId by viewModel.userId.collectAsState()
     val displayName by viewModel.displayName.collectAsState()
+    val isLoadingDisplayName by viewModel.isLoadingDisplayName.collectAsState()
     val accountCreationError by viewModel.accountCreationError.collectAsState()
     val isUpdatingParrotName by viewModel.isUpdatingParrotName.collectAsState()
     val nameUpdateError by viewModel.nameUpdateError.collectAsState()
@@ -79,6 +80,8 @@ fun SettingsScreen() {
     // タブ切り替え時に最新情報を取得
     LaunchedEffect(Unit) {
         viewModel.refreshAll()
+        // 他の画面で名前が変更されている可能性があるため強制的に再読み込み
+        viewModel.forceReloadDisplayName()
     }
 
     // アカウント作成ボトムシートの状態
@@ -176,19 +179,31 @@ fun SettingsScreen() {
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
-                                Text(
-                                    text = displayName?.takeIf { it.isNotBlank() } ?: "ひよっこインコ",
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    color = Secondary,
-                                    fontWeight = FontWeight.Medium,
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .background(
-                                            color = Secondary.copy(alpha = 0.1f),
-                                            shape = RoundedCornerShape(16.dp)
-                                        )
-                                        .padding(horizontal = 16.dp, vertical = 12.dp)
-                                )
+                                if (isLoadingDisplayName && displayName == null) {
+                                    androidx.compose.foundation.layout.Box(
+                                        modifier = Modifier
+                                            .weight(1f)
+                                            .height(44.dp)
+                                            .background(
+                                                color = Secondary.copy(alpha = 0.1f),
+                                                shape = RoundedCornerShape(16.dp)
+                                            )
+                                    )
+                                } else {
+                                    Text(
+                                        text = displayName?.takeIf { it.isNotBlank() } ?: "ひよっこインコ",
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = Secondary,
+                                        fontWeight = FontWeight.Medium,
+                                        modifier = Modifier
+                                            .weight(1f)
+                                            .background(
+                                                color = Secondary.copy(alpha = 0.1f),
+                                                shape = RoundedCornerShape(16.dp)
+                                            )
+                                            .padding(horizontal = 16.dp, vertical = 12.dp)
+                                    )
+                                }
 
                                 IconButton(
                                     onClick = {

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/SettingsScreen.kt
@@ -144,7 +144,7 @@ fun SettingsScreen() {
                 .padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // インコじょうほうカード（アカウント作成済みの場合のみ表示）
+            // リマインネット設定（アカウント作成済みの場合のみ表示）
             if (userId != null) {
                 Card(
                     modifier = Modifier.fillMaxWidth(),
@@ -156,7 +156,7 @@ fun SettingsScreen() {
                         modifier = Modifier.padding(20.dp)
                     ) {
                         Text(
-                            text = "インコじょうほう",
+                            text = "リマインネット",
                             style = MaterialTheme.typography.titleMedium,
                             color = Secondary,
                             fontWeight = FontWeight.Bold
@@ -253,31 +253,8 @@ fun SettingsScreen() {
                                 color = Secondary.copy(alpha = 0.7f)
                             )
                         }
-                    }
-                }
-            }
 
-            // リマインネット設定（アカウント作成済みの場合のみ表示）
-            if (userId != null) {
-                Spacer(modifier = Modifier.height(24.dp))
-
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(16.dp),
-                    colors = CardDefaults.cardColors(containerColor = CardBackgroundColor),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
-                ) {
-                    Column(
-                        modifier = Modifier.padding(20.dp)
-                    ) {
-                        Text(
-                            text = "リマインネット",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = Secondary,
-                            fontWeight = FontWeight.Bold
-                        )
-
-                        Spacer(modifier = Modifier.height(16.dp))
+                        Spacer(modifier = Modifier.height(20.dp))
 
                         // リマインネット投稿設定
                         Row(

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/util/Constants.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/util/Constants.kt
@@ -1,0 +1,11 @@
+package com.maropiyo.reminderparrot.util
+
+/**
+ * アプリケーション全体で使用される定数
+ */
+object Constants {
+    /**
+     * ユーザー名更新のクールダウン時間（ミリ秒）
+     */
+    const val NAME_UPDATE_COOLDOWN_MS = 2000L
+}


### PR DESCRIPTION
## Summary
- リマインネット参加フローを4段階から2段階に簡素化
- 投稿削除時のボトムシート表示問題を修正
- UI文言とボタンデザインの統一

## Test plan
- [ ] リマインネット参加フローが2段階で正常に動作することを確認
- [ ] 投稿削除時にボトムシートが即座に閉じることを確認
- [ ] ボタン色が統一されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)