### PR TITLE
feat(ui): リマインネット投稿にユーザーレベル表示機能を追加

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/datasource/remote/RemindNetRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/datasource/remote/RemindNetRemoteDataSource.kt
@@ -31,7 +31,8 @@ class RemindNetRemoteDataSource(
         reminderText: String,
         forgetAt: Instant,
         userId: String?,
-        userName: String?
+        userName: String?,
+        userLevel: Int? = null
     ): Result<RemindNetPost> = try {
         val dto =
             RemindNetPostDto(
@@ -39,6 +40,7 @@ class RemindNetRemoteDataSource(
                 reminderText = reminderText,
                 userId = userId,
                 userName = userName ?: "ひよっこインコ",
+                userLevel = userLevel,
                 forgetAt = forgetAt.toString()
             )
 
@@ -241,6 +243,7 @@ data class RemindNetPostDto(
     @SerialName("reminder_text") val reminderText: String,
     @SerialName("user_id") val userId: String? = null,
     @SerialName("user_name") val userName: String = "ひよっこインコ",
+    @SerialName("user_level") val userLevel: Int? = null,
     @SerialName("forget_at") val forgetAt: String
 )
 
@@ -250,6 +253,7 @@ data class RemindNetPostResponseDto(
     @SerialName("reminder_text") val reminderText: String,
     @SerialName("user_id") val userId: String?,
     @SerialName("user_name") val userName: String,
+    @SerialName("user_level") val userLevel: Int? = null,
     @SerialName("created_at") val createdAt: String,
     @SerialName("forget_at") val forgetAt: String,
     @SerialName("likes_count") val likesCount: Int,
@@ -260,6 +264,7 @@ data class RemindNetPostResponseDto(
         reminderText = reminderText,
         userId = userId,
         userName = userName,
+        userLevel = userLevel,
         createdAt = Instant.parse(createdAt),
         forgetAt = Instant.parse(forgetAt),
         likesCount = likesCount,

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/repository/RemindNetRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/repository/RemindNetRepositoryImpl.kt
@@ -20,9 +20,10 @@ class RemindNetRepositoryImpl(
         reminderText: String,
         forgetAt: Instant,
         userId: String?,
-        userName: String?
+        userName: String?,
+        userLevel: Int?
     ): Result<RemindNetPost> {
-        return remoteDataSource.createPost(reminderId, reminderText, forgetAt, userId, userName)
+        return remoteDataSource.createPost(reminderId, reminderText, forgetAt, userId, userName, userLevel)
     }
 
     override fun getAllPosts(): Flow<List<RemindNetPost>> {

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/di/AppModule.kt
@@ -82,7 +82,7 @@ val appModule =
         single<ScheduleForgetNotificationUseCase> { ScheduleForgetNotificationUseCase(get()) }
         single<CancelForgetNotificationUseCase> { CancelForgetNotificationUseCase(get()) }
         single<RequestNotificationPermissionUseCase> { RequestNotificationPermissionUseCase(get()) }
-        single<CreateRemindNetPostUseCase> { CreateRemindNetPostUseCase(get(), get()) }
+        single<CreateRemindNetPostUseCase> { CreateRemindNetPostUseCase(get(), get(), get()) }
         single<DeleteRemindNetPostUseCase> { DeleteRemindNetPostUseCase(get()) }
         single<GetRemindNetPostsUseCase> { GetRemindNetPostsUseCase(get()) }
         single<SendRemindNotificationUseCase> { SendRemindNotificationUseCase(get(), get(), get()) }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/entity/RemindNetPost.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/entity/RemindNetPost.kt
@@ -12,6 +12,7 @@ data class RemindNetPost(
     val reminderText: String,
     val userId: String?,
     val userName: String = "ひよっこインコ",
+    val userLevel: Int? = null,
     val createdAt: Instant,
     val forgetAt: Instant,
     val likesCount: Int = 0,

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/repository/RemindNetRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/repository/RemindNetRepository.kt
@@ -17,7 +17,8 @@ interface RemindNetRepository {
         reminderText: String,
         forgetAt: kotlinx.datetime.Instant,
         userId: String? = null,
-        userName: String? = null
+        userName: String? = null,
+        userLevel: Int? = null
     ): Result<RemindNetPost>
 
     /**

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/remindnet/CreateRemindNetPostUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/usecase/remindnet/CreateRemindNetPostUseCase.kt
@@ -1,6 +1,7 @@
 package com.maropiyo.reminderparrot.domain.usecase.remindnet
 
 import com.maropiyo.reminderparrot.domain.entity.RemindNetPost
+import com.maropiyo.reminderparrot.domain.repository.ParrotRepository
 import com.maropiyo.reminderparrot.domain.repository.RemindNetRepository
 import com.maropiyo.reminderparrot.domain.service.AuthService
 import kotlinx.datetime.Instant
@@ -10,7 +11,8 @@ import kotlinx.datetime.Instant
  */
 class CreateRemindNetPostUseCase(
     private val remindNetRepository: RemindNetRepository,
-    private val authService: AuthService
+    private val authService: AuthService,
+    private val parrotRepository: ParrotRepository
 ) {
     suspend operator fun invoke(
         reminderId: String,
@@ -23,6 +25,9 @@ class CreateRemindNetPostUseCase(
         // パラメータで指定されていない場合はSupabaseAuthから取得
         val actualUserName = userName ?: authService.getDisplayName()
 
-        return remindNetRepository.createPost(reminderId, reminderText, forgetAt, userId, actualUserName)
+        // ローカルのインコからレベル情報を取得
+        val userLevel = parrotRepository.getParrot().getOrNull()?.level
+
+        return remindNetRepository.createPost(reminderId, reminderText, forgetAt, userId, actualUserName, userLevel)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/LevelUpPopup.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/LevelUpPopup.kt
@@ -119,7 +119,7 @@ fun LevelUpDialog(isVisible: Boolean, parrot: Parrot, onDismiss: () -> Unit) {
 
                     // レベル表示
                     Text(
-                        text = "レベル ${parrot.level}",
+                        text = "Lv.${parrot.level}",
                         fontSize = 24.sp,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.primary

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ParrotContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/ParrotContent.kt
@@ -81,7 +81,7 @@ fun ParrotContent(state: ParrotState, modifier: Modifier = Modifier) {
             ) {
                 // レベル表示
                 Text(
-                    text = "レベル${state.parrot.level}",
+                    text = "Lv.${state.parrot.level}",
                     style =
                     MaterialTheme.typography.labelMedium.copy(
                         fontWeight = FontWeight.Bold,

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -611,6 +611,11 @@ private fun RemindNetPostCard(
                             overflow = TextOverflow.Ellipsis
                         )
 
+                        // レベルバッジ
+                        if (post.userLevel != null) {
+                            UserLevelBadge(level = post.userLevel)
+                        }
+
                         // あなたの投稿
                         if (isMyPost) {
                             Box(
@@ -932,6 +937,11 @@ private fun PostDetailCard(
                             fontWeight = FontWeight.Bold,
                             color = Secondary
                         )
+
+                        // レベルバッジ
+                        if (post.userLevel != null) {
+                            UserLevelBadge(level = post.userLevel)
+                        }
 
                         // スマートな投稿者表示
                         if (isMyPost) {
@@ -1272,6 +1282,39 @@ private fun SimpleParrotInfoDisplay(
                     )
                 }
             }
+        }
+    }
+}
+
+/**
+ * ユーザーレベルを表示するバッジコンポーネント
+ */
+@Composable
+private fun UserLevelBadge(level: Int, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .background(
+                color = Primary.copy(alpha = 0.1f),
+                shape = RoundedCornerShape(12.dp)
+            )
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = "Lv",
+                style = MaterialTheme.typography.labelSmall,
+                color = Primary,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = level.toString(),
+                style = MaterialTheme.typography.labelSmall,
+                color = Primary,
+                fontWeight = FontWeight.Bold
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.maropiyo.reminderparrot.domain.entity.RemindNetPost
 import com.maropiyo.reminderparrot.domain.usecase.RegisterPushNotificationTokenUseCase
 import com.maropiyo.reminderparrot.presentation.viewmodel.ParrotViewModel
@@ -597,44 +598,13 @@ private fun RemindNetPostCard(
                 Column(
                     modifier = Modifier.weight(1f)
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        // ユーザー名
-                        Text(
-                            text = post.userName,
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = FontWeight.Bold,
-                            color = Secondary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-
-                        // レベルバッジ
-                        if (post.userLevel != null) {
-                            UserLevelBadge(level = post.userLevel)
-                        }
-
-                        // あなたの投稿
-                        if (isMyPost) {
-                            Box(
-                                modifier = Modifier
-                                    .background(
-                                        color = Secondary.copy(alpha = 0.1f),
-                                        shape = RoundedCornerShape(16.dp)
-                                    )
-                                    .padding(horizontal = 8.dp, vertical = 4.dp)
-                            ) {
-                                Text(
-                                    text = "あなた",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = Secondary,
-                                    fontWeight = FontWeight.Medium
-                                )
-                            }
-                        }
-                    }
+                    UserInfoRow(
+                        post = post,
+                        isMyPost = isMyPost,
+                        showMyPostBadge = true,
+                        textStyle = MaterialTheme.typography.titleSmall,
+                        badgeSize = BadgeSize.Default
+                    )
 
                     // 投稿時間
                     Text(
@@ -926,26 +896,13 @@ private fun PostDetailCard(
                 Column(
                     modifier = Modifier.weight(1f)
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        // ユーザー名
-                        Text(
-                            text = post.userName,
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = Secondary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f, fill = false)
-                        )
-
-                        // レベルバッジ
-                        if (post.userLevel != null) {
-                            UserLevelBadge(level = post.userLevel)
-                        }
-                    }
+                    UserInfoRow(
+                        post = post,
+                        isMyPost = isMyPost,
+                        showMyPostBadge = false,
+                        textStyle = MaterialTheme.typography.titleMedium,
+                        badgeSize = BadgeSize.Default
+                    )
 
                     // 投稿時間
                     Text(
@@ -1271,30 +1228,119 @@ private fun SimpleParrotInfoDisplay(
 }
 
 /**
+ * ユーザー情報を表示する共通コンポーネント
+ */
+@Composable
+private fun UserInfoRow(
+    post: RemindNetPost,
+    isMyPost: Boolean,
+    showMyPostBadge: Boolean = true,
+    textStyle: androidx.compose.ui.text.TextStyle = MaterialTheme.typography.titleSmall,
+    badgeSize: BadgeSize = BadgeSize.Default,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier
+    ) {
+        // ユーザー名
+        Text(
+            text = post.userName,
+            style = textStyle,
+            fontWeight = FontWeight.Bold,
+            color = Secondary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = if (showMyPostBadge) Modifier.weight(1f, fill = false) else Modifier
+        )
+
+        // レベルバッジ
+        if (post.userLevel != null) {
+            UserLevelBadge(level = post.userLevel, size = badgeSize)
+        }
+
+        // あなたの投稿バッジ（オプション）
+        if (isMyPost && showMyPostBadge) {
+            Box(
+                modifier = Modifier
+                    .background(
+                        color = Secondary.copy(alpha = 0.1f),
+                        shape = RoundedCornerShape(16.dp)
+                    )
+                    .padding(horizontal = 8.dp, vertical = 4.dp)
+            ) {
+                Text(
+                    text = "あなた",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Secondary,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        }
+    }
+}
+
+/**
+ * バッジサイズを定義するenum
+ */
+enum class BadgeSize(
+    val textStyle: androidx.compose.ui.text.TextStyle,
+    val horizontalPadding: androidx.compose.ui.unit.Dp,
+    val verticalPadding: androidx.compose.ui.unit.Dp,
+    val cornerRadius: androidx.compose.ui.unit.Dp
+) {
+    Small(
+        textStyle = androidx.compose.ui.text.TextStyle(fontSize = 10.sp),
+        horizontalPadding = 6.dp,
+        verticalPadding = 2.dp,
+        cornerRadius = 8.dp
+    ),
+    Default(
+        textStyle = androidx.compose.ui.text.TextStyle(fontSize = 12.sp),
+        horizontalPadding = 8.dp,
+        verticalPadding = 4.dp,
+        cornerRadius = 12.dp
+    ),
+    Large(
+        textStyle = androidx.compose.ui.text.TextStyle(fontSize = 14.sp),
+        horizontalPadding = 10.dp,
+        verticalPadding = 6.dp,
+        cornerRadius = 16.dp
+    )
+}
+
+/**
  * ユーザーレベルを表示するバッジコンポーネント
  */
 @Composable
-private fun UserLevelBadge(level: Int, modifier: Modifier = Modifier) {
+private fun UserLevelBadge(level: Int, modifier: Modifier = Modifier, size: BadgeSize = BadgeSize.Default) {
     Box(
         modifier = modifier
             .background(
                 color = Primary.copy(alpha = 0.1f),
-                shape = RoundedCornerShape(12.dp)
+                shape = RoundedCornerShape(size.cornerRadius)
             )
-            .padding(horizontal = 8.dp, vertical = 4.dp)
+            .padding(horizontal = size.horizontalPadding, vertical = size.verticalPadding)
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
                 text = "Lv.",
-                style = MaterialTheme.typography.bodySmall,
+                style = size.textStyle.copy(
+                    color = Primary,
+                    fontWeight = FontWeight.Medium
+                ),
                 color = Primary,
                 fontWeight = FontWeight.Medium
             )
             Text(
                 text = level.toString(),
-                style = MaterialTheme.typography.bodySmall,
+                style = size.textStyle.copy(
+                    color = Primary,
+                    fontWeight = FontWeight.Bold
+                ),
                 color = Primary,
                 fontWeight = FontWeight.Bold
             )

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/screens/RemindNetScreen.kt
@@ -935,31 +935,15 @@ private fun PostDetailCard(
                             text = post.userName,
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold,
-                            color = Secondary
+                            color = Secondary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false)
                         )
 
                         // レベルバッジ
                         if (post.userLevel != null) {
                             UserLevelBadge(level = post.userLevel)
-                        }
-
-                        // スマートな投稿者表示
-                        if (isMyPost) {
-                            Box(
-                                modifier = Modifier
-                                    .background(
-                                        color = Secondary.copy(alpha = 0.1f),
-                                        shape = RoundedCornerShape(16.dp)
-                                    )
-                                    .padding(horizontal = 12.dp, vertical = 6.dp)
-                            ) {
-                                Text(
-                                    text = "あなた",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = Secondary,
-                                    fontWeight = FontWeight.Medium
-                                )
-                            }
                         }
                     }
 
@@ -1300,18 +1284,17 @@ private fun UserLevelBadge(level: Int, modifier: Modifier = Modifier) {
             .padding(horizontal = 8.dp, vertical = 4.dp)
     ) {
         Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp)
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "Lv",
-                style = MaterialTheme.typography.labelSmall,
+                text = "Lv.",
+                style = MaterialTheme.typography.bodySmall,
                 color = Primary,
                 fontWeight = FontWeight.Medium
             )
             Text(
                 text = level.toString(),
-                style = MaterialTheme.typography.labelSmall,
+                style = MaterialTheme.typography.bodySmall,
                 color = Primary,
                 fontWeight = FontWeight.Bold
             )


### PR DESCRIPTION
## Summary
- リマインネット投稿にユーザーのレベル情報を表示する機能を実装
- 投稿作成時にローカルのインコレベルをSupabaseに送信
- 投稿カードと詳細画面にレベルバッジを表示
- アプリ全体のレベル表記を「Lv.X」形式に統一

## 主な変更内容

### バックエンド統合
- `RemindNetPost`エンティティに`userLevel`フィールド追加
- `RemindNetPostDto`と`RemindNetPostResponseDto`にレベル情報を追加
- `CreateRemindNetPostUseCase`でローカルインコのレベルを取得・送信
- Repository層とDI設定を更新

### UI改善
- 投稿カードと詳細画面に「Lv.X」形式のレベルバッジを追加
- ホーム画面とレベルアップダイアログの表記も統一
- 詳細画面の「あなた」バッジを削除してレイアウト改善
- レベルバッジの文字サイズと配置を最適化

### Supabase対応
- `remind_net_posts`テーブルに`user_level`カラム追加
- デフォルト値を「ひよっこインコ」に統一

## Test plan
- [ ] 新規投稿作成時にレベル情報が正しく送信される
- [ ] 投稿リストでレベルバッジが適切に表示される
- [ ] 投稿詳細画面でレベルバッジが表示される
- [ ] ホーム画面のレベル表示が統一されている
- [ ] レベルアップダイアログの表記が統一されている
- [ ] 既存投稿（レベル情報なし）でバッジが表示されない

🤖 Generated with [Claude Code](https://claude.ai/code)