### PR TITLE
refactor: いいね機能を削除

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/datasource/remote/RemindNetRemoteDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/datasource/remote/RemindNetRemoteDataSource.kt
@@ -81,26 +81,6 @@ class RemindNetRemoteDataSource(
     }
 
     /**
-     * 投稿にいいねをする
-     */
-    suspend fun likePost(postId: String): Result<Unit> = try {
-        // いいね数をインクリメント
-        supabaseClient
-            .from("remind_net_posts")
-            .update({
-                set("likes_count", "likes_count + 1")
-            }) {
-                filter {
-                    eq("id", postId)
-                }
-            }
-
-        Result.success(Unit)
-    } catch (e: Exception) {
-        Result.failure(e)
-    }
-
-    /**
      * 投稿を削除する（物理削除）
      */
     suspend fun deletePost(postId: String, userId: String): Result<Unit> {
@@ -256,7 +236,6 @@ data class RemindNetPostResponseDto(
     @SerialName("user_level") val userLevel: Int? = null,
     @SerialName("created_at") val createdAt: String,
     @SerialName("forget_at") val forgetAt: String,
-    @SerialName("likes_count") val likesCount: Int,
     @SerialName("is_deleted") val isDeleted: Boolean
 ) {
     fun toEntity(): RemindNetPost = RemindNetPost(
@@ -267,7 +246,6 @@ data class RemindNetPostResponseDto(
         userLevel = userLevel,
         createdAt = Instant.parse(createdAt),
         forgetAt = Instant.parse(forgetAt),
-        likesCount = likesCount,
         isDeleted = isDeleted
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/repository/RemindNetRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/data/repository/RemindNetRepositoryImpl.kt
@@ -30,10 +30,6 @@ class RemindNetRepositoryImpl(
         return remoteDataSource.getAllPosts()
     }
 
-    override suspend fun likePost(postId: String): Result<Unit> {
-        return remoteDataSource.likePost(postId)
-    }
-
     override suspend fun deletePost(postId: String, userId: String): Result<Unit> {
         return remoteDataSource.deletePost(postId, userId)
     }

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/entity/RemindNetPost.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/entity/RemindNetPost.kt
@@ -15,7 +15,6 @@ data class RemindNetPost(
     val userLevel: Int? = null,
     val createdAt: Instant,
     val forgetAt: Instant,
-    val likesCount: Int = 0,
     val isDeleted: Boolean = false
 ) {
     /**

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/repository/RemindNetRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/domain/repository/RemindNetRepository.kt
@@ -27,11 +27,6 @@ interface RemindNetRepository {
     fun getAllPosts(): Flow<List<RemindNetPost>>
 
     /**
-     * 投稿にいいねをする
-     */
-    suspend fun likePost(postId: String): Result<Unit>
-
-    /**
      * 投稿を削除する
      */
     suspend fun deletePost(postId: String, userId: String): Result<Unit>


### PR DESCRIPTION
## Summary
- いいね機能をすべての層から削除しました
- RemindNetPostエンティティからlikesCountフィールドを削除
- RemindNetRepositoryからlikePostメソッドを削除
- RemindNetRemoteDataSourceからいいね関連のロジックを削除
- Supabaseテーブルからlikes_countカラムを削除

## 変更内容
### Domain層
- `RemindNetPost.kt`: likesCountフィールドを削除
- `RemindNetRepository.kt`: likePostメソッドを削除

### Data層  
- `RemindNetRepositoryImpl.kt`: likePost実装を削除
- `RemindNetRemoteDataSource.kt`: いいね関連DTO、メソッドを削除

### Database
- Supabaseテーブルからlikes_countカラムを削除

## Test plan
- [x] ktlintCheck実行済み
- [x] allTests実行済み
- [x] ビルドエラーなし

🤖 Generated with [Claude Code](https://claude.ai/code)