### PR TITLE
fix: ボトムシートのちらつきとAndroidキーボード表示時のUI問題を修正

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -18,6 +18,7 @@
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
             android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustNothing"
             android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/AddReminderBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/AddReminderBottomSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -190,6 +191,14 @@ private fun ReminderTextField(
                 text = reminderText,
                 selection = TextRange(reminderText.length)
             )
+        )
+    }
+
+    // reminderTextが変更された場合に同期（ボトムシート表示時のリセット対応）
+    LaunchedEffect(reminderText) {
+        textFieldValue = TextFieldValue(
+            text = reminderText,
+            selection = TextRange(reminderText.length)
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/EditReminderBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/maropiyo/reminderparrot/ui/components/home/EditReminderBottomSheet.kt
@@ -213,15 +213,12 @@ private fun EditReminderTextField(
         )
     }
 
-    // リマインダーテキストが外部から変更された場合に同期
+    // リマインダーテキストが外部から変更された場合に同期（ボトムシート表示時のリセット対応）
     LaunchedEffect(reminderText) {
-        if (textFieldValue.text != reminderText) {
-            textFieldValue =
-                TextFieldValue(
-                    text = reminderText,
-                    selection = TextRange(reminderText.length)
-                )
-        }
+        textFieldValue = TextFieldValue(
+            text = reminderText,
+            selection = TextRange(reminderText.length)
+        )
     }
 
     TextField(


### PR DESCRIPTION
## 概要
ボトムシートのちらつき問題とAndroidでのキーボード表示時のUI問題を修正しました。

## 修正内容

### 1. ボトムシートTextFieldValueちらつき問題
**問題**: キーボード表示→非表示後にボトムシートを再表示すると、一瞬展開状態で表示されてちらつく
**原因**: TextFieldのremember状態が残存し、ボトムシート再表示時に前回の状態が使用される
**解決**: LaunchedEffectを使用してreminderTextの変更に連動してTextFieldValueを確実にリセット

### 2. Androidキーボード表示時のボトムナビゲーション移動問題
**問題**: Androidでキーボードを表示すると、ボトムナビゲーションバーが一緒に上がってくる
**原因**: `windowSoftInputMode`の設定が不足
**解決**: AndroidManifest.xmlに`android:windowSoftInputMode="adjustNothing"`を追加

## 技術的な変更

### AddReminderBottomSheet.kt
- LaunchedEffectを追加してTextFieldValueの状態同期を改善
- reminderTextが変更されたときに確実にTextFieldValueをリセット

### EditReminderBottomSheet.kt  
- 既存のLaunchedEffectを改良し、条件チェックを削除して無条件リセットに変更
- 初期表示時の問題を解決

### AndroidManifest.xml
- `android:windowSoftInputMode="adjustNothing"`を追加
- キーボード表示時にレイアウトを変更しないよう設定

## 期待される効果
- ✅ キーボード操作後のボトムシート再表示が正常に動作
- ✅ AndroidとiOSで一貫したUI動作を実現
- ✅ ユーザー体験の向上

## テスト状況
- ✅ コードスタイルチェック (ktlint)
- ✅ Androidビルド確認
- ✅ 全テスト通過
- ✅ 実機での動作確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)